### PR TITLE
Feat/delete

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,7 @@
+Version 0.2.0
+  - add: org-remark-delete
+
+Version 0.1.0
 * Features & additions
 
   - docs: comprehensive user manual (online - Info to be added on ELPA release)
@@ -12,7 +16,7 @@
   - add: browse-next/prev: move and display next/prev marginal notes at the same
          time
 
-  - add: visit/open to display side-window by default (user option)
+  - add: view/open to display side-window by default (user option)
 
   - add: org-remark-link property in marginal notes file with ::line-number
          search option
@@ -33,7 +37,7 @@
 
   - chg: define org-remark-mark explicitly for autoload cookie
 
-  - chg: `org-remark-visit' and `org-remark-open'. Visit will stay in the
+  - chg: `org-remark-view' and `org-remark-open'. View will stay in the
           current main note; open will move the cursor to the marginal notes
           buffer for further editing.
 

--- a/README.org
+++ b/README.org
@@ -105,12 +105,5 @@ This work is licensed under a GPLv3 license. For a full copy of the license, ref
 This section is created by Org-remark for the source file. It serves as an example to illustrate what Org-remark can do.
 
 ** defmacro org-remark-create
-:PROPERTIES:
-:org-remark-beg: 4001
-:org-remark-end: 4027
-:org-remark-id: c759f435
-:org-remark-label: nil
-:org-remark-link: [[file:~/src/org-remark/org-remark.el::120]]
-:END:
 
 This macro was inspired by [[https://github.com/jkitchin/ov-highlight][Ov-highlight]].  It's by John Kitchin (author of Org-ref). Great UX for markers with hydra. Saves the marker info and comments directly within the Org file as Base64 encoded string. It uses overlays with using ~ov~ package.


### PR DESCRIPTION
  "Delete the highlight at POINT and marginal notes for it.

This function will prompt for confirmation if there is any notes
present in the marginal notes buffer.  When the marginal notes
buffer is not displayed in the current frame, it will be
temporarily displayed together with the prompt for the user to
see the notes.

If there is no notes, this function will not prompt for
confirmation and will remove the highlight and deletes the entry
in the marginal notes buffer.

This command is identical with passing a universal argument to
`org-remark-remove'. "
