### PR TITLE
Add user options for links between main and notes files; simplify org-remark-global-tracking

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,15 @@
 Current development version
 
+  - chg: `org-remark-global-tracking-mode' has been simplified.
+
+         .org-remark-tracking file is no longer necessary and can be safely
+         deleted from the user's Emacs configuraiton directory if present.
+         Automatic activation of `org-remark-mode' is done by looking the
+         presence of a marginal notes file for current buffer open.
+
+         `org-remark-global-tracking-mode' itself is still relevant and
+         recommended to be setup as was previously in the user manual.
+
   - add: Option to use relative links from the marginal notes back to the source
 
          Adding user option org-remark-source-path-function.  The default is

--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,9 @@ Current development version
 
   - chg: `org-remark-global-tracking-mode' has been simplified.
 
+         This is not expected to break the user's workflow or configuration
+         -- simply removing a superfluous feature.   
+
          .org-remark-tracking file is no longer necessary and can be safely
          deleted from the user's Emacs configuraiton directory if present.
          Automatic activation of `org-remark-mode' is done by looking the

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,17 @@
+Current development version
+
+  - add: Option to use relative links from the marginal notes back to the source
+
+         Adding user option org-remark-source-path-function.  The default is
+         file-relative-name.
+
+  - add: Adding a new option to org-remark-notes-file-path to use a function
+
+         Its default function is org-remark-notes-file-path-function.  It
+         returns a file name like this: "FILE-notes.org" by adding
+         "-notes.org" as a suffix to the file name without the extension.
+
+
 Version 0.2.0
   - add: org-remark-delete
   - rm: Adding Org-ID automatically to file level when file is empty


### PR DESCRIPTION
  - chg: `org-remark-global-tracking-mode' has been simplified.

         .org-remark-tracking file is no longer necessary and can be safely
         deleted from the user's Emacs configuration directory if present.
         Automatic activation of `org-remark-mode' is done by looking the
         presence of a marginal notes file for current buffer open.

         `org-remark-global-tracking-mode' itself is still relevant and
         recommended to be setup as was previously in the user manual.

         This is not expected to break the user's workflow -- removing a superfluous feature.

  - add: Option to use relative links from the marginal notes back to the source

         Adding user option org-remark-source-path-function.  The default is
         file-relative-name.

  - add: Adding a new option to org-remark-notes-file-path to use a function

         Its default function is org-remark-notes-file-path-function.  It
         returns a file name like this: "FILE-notes.org" by adding
         "-notes.org" as a suffix to the file name without the extension.