### PR TITLE
chg: align with GNU convention: path -> file name

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,9 +1,40 @@
 Current development version
+  - chg: align with GNU convention: path -> file name
+
+        Regarding user option `org-remark-notes-file-path`, the GNU convention
+        is to call this a "file name" rather than a "path"; "path" is only used
+        for lists of directories as in `load-path` (pointed out by Stefan
+        Monnier; thank you).
+
+        To align with the GNU convention, the following changes are done.  Users
+        should not have to change their existing customization as the old names
+        are aliased to the new ones.
+
+        User option:
+        - org-remark-notes-file-path -> org-remark-notes-file-name
+        - org-remark-source-path-function -> 'org-remark-source-file-name
+
+        Function:
+        - org-remark-notes-file-path-function -> org-remark-notes-file-name-function
+
+        Private Function:
+        - org-remark-notes-get-file-path -> org-remark-notes-get-file-name
+
+        `org-remark-notes-file-path`, `org-remark-source-path-function`, and
+        `org-remark-notes-file-path-function` are used by existing
+        customization, thus both explicitly made obsolete and aliased to the new
+        file-name equivalents.
+
+  - fix: Relative file name of the source file in the notes file
+
+         The relative file name of the source was not relative from the marginal notes
+         file but from the source file itself -- this should be relative from the
+         marginal notes.
 
   - chg: `org-remark-global-tracking-mode' has been simplified.
 
          This is not expected to break the user's workflow or configuration
-         -- simply removing a superfluous feature.   
+         -- simply removing a superfluous feature.
 
          .org-remark-tracking file is no longer necessary and can be safely
          deleted from the user's Emacs configuraiton directory if present.

--- a/demo/marginalia.org
+++ b/demo/marginalia.org
@@ -1,7 +1,19 @@
+
 * demo
 :PROPERTIES:
-:org-remark-file: ~/src/org-remark/demo/demo.txt
+:org-remark-file: demo.txt
 :END:
+
+** World War I
+:PROPERTIES:
+:org-remark-beg: 633
+:org-remark-end: 644
+:org-remark-id: 598a701e
+:org-remark-label: nil
+:CATEGORY: exam
+:org-remark-link: [[file:~/src/org-remark/demo/demo.txt::10]]
+:END:
+
 
 ** Highlight
 :PROPERTIES:
@@ -104,24 +116,3 @@ Annotation for the 19th centry.
 :CATEGORY: exam
 :org-remark-link: [[file:~/src/org-remark/demo/demo.txt::10]]
 :END:
-
-** World War I
-:PROPERTIES:
-:org-remark-beg: 633
-:org-remark-end: 644
-:org-remark-id: 598a701e
-:org-remark-label: nil
-:CATEGORY: exam
-:org-remark-link: [[file:~/src/org-remark/demo/demo.txt::10]]
-:END:
-
-** particularly iron
-:PROPERTIES:
-:org-remark-beg: 1019
-:org-remark-end: 1036
-:org-remark-id: 895c6dfe
-:org-remark-label: nil
-:org-remark-link: [[file:~/src/org-remark/demo/demo.txt::10]]
-:END:
-
-

--- a/org-remark-global-tracking.el
+++ b/org-remark-global-tracking.el
@@ -5,7 +5,7 @@
 ;; Author: Noboru Ota <me@nobiot.com>
 ;; URL: https://github.com/nobiot/org-remark
 ;; Created: 15 August 2021
-;; Last modified: 01 February 2022
+;; Last modified: 05 February 2022
 ;; Package-Requires: ((emacs "27.1") (org "9.4"))
 ;; Keywords: org-mode, annotation, writing, note-taking, marginal notes
 
@@ -31,7 +31,7 @@
 
 (declare-function org-remark-mode "org-remark")
 
-(defcustom org-remark-notes-file-path "marginalia.org"
+(defcustom org-remark-notes-file-name "marginalia.org"
   "Define the file path to store the location of highlights and write annotations.
 It can be either a string or function.
 
@@ -40,14 +40,18 @@ file.  The default is \"marginalia.org\".  It will be one marginal
 notes file per directory.  Ensure that it is an Or file.
 
 If it is a function, the default function is
-`org-remark-notes-file-path-function'.  It returns a file name
+`org-remark-notes-file-name-function'.  It returns a file name
 like this: \"FILE-notes.org\" by adding \"-notes.org\" as a
 suffix to the file name without the extension."
   :group 'org-remark
   :safe #'stringp
   :type '(choice
           (file "marginalia.org")
-          (function org-remark-notes-file-path-function)))
+          (function org-remark-notes-file-name-function)))
+
+(defvaralias 'org-remark-notes-file-path 'org-remark-notes-file-name)
+(make-obsolete-variable
+ 'org-remark-notes-file-path 'org-remark-notes-file-name "0.2.0")
 
 ;;;###autoload
 (define-minor-mode org-remark-global-tracking-mode
@@ -68,29 +72,7 @@ readable, the function automatically activates `org-remark'."
     ;; Deactivate
     (remove-hook 'find-file-hook #'org-remark-auto-on))))
 
-;;;; Private Functions
-
-(defun org-remark-auto-on ()
-  "Automatically activates `org-remark-mode' for current buffer when relevant.
-This function is meant to be addd to `find-file-hook' by
-`org-remark-global-tracking-mode'."
-  (when-let (notes-file (org-remark-notes-get-file-path))
-    (when (file-readable-p notes-file)
-      (unless (featurep 'org-remark) (require 'org-remark))
-      (org-remark-mode +1))))
-
-(defun org-remark-notes-get-file-path ()
-  "Return the file path to the marginal notes for current buffer.
-This function looks at customization variable
-`org-remark-notes-file-path'.  If it is a string, return it as
-the file path.  If it is a function, evaluate it to return the
-value."
-  (if (functionp org-remark-notes-file-path)
-      (funcall org-remark-notes-file-path)
-    ;; If not function, assume string and return it as the file path.
-    org-remark-notes-file-path))
-
-(defun org-remark-notes-file-path-function ()
+(defun org-remark-notes-file-name-function ()
   "Return a marginal notes file name for the current buffer.
 
 This is the default function for the customizing variable
@@ -100,6 +82,33 @@ When the current buffer is visiting a FILE, the name of marginal
 notes file will be \"FILE-notes.org\", adding \"-notes.org\" as a
 suffix to the file name without the extension."
   (concat (file-name-sans-extension (buffer-file-name)) "-notes.org"))
+
+(defalias
+  'org-remark-notes-file-path-function 'org-remark-notes-file-name-function)
+(make-obsolete
+ 'org-remark-notes-file-path-function 'org-remark-notes-file-name-function "0.2.0" )
+
+;;;; Private Functions
+
+(defun org-remark-auto-on ()
+  "Automatically activates `org-remark-mode' for current buffer when relevant.
+This function is meant to be addd to `find-file-hook' by
+`org-remark-global-tracking-mode'."
+  (when-let (notes-file (org-remark-notes-get-file-name))
+    (when (file-readable-p notes-file)
+      (unless (featurep 'org-remark) (require 'org-remark))
+      (org-remark-mode +1))))
+
+(defun org-remark-notes-get-file-name ()
+  "Return the file path to the marginal notes for current buffer.
+This function looks at customization variable
+`org-remark-notes-file-path'.  If it is a string, return it as
+the file path.  If it is a function, evaluate it to return the
+value."
+  (if (functionp org-remark-notes-file-path)
+      (funcall org-remark-notes-file-path)
+    ;; If not function, assume string and return it as the file path.
+    org-remark-notes-file-path))
 
 (provide 'org-remark-global-tracking)
 

--- a/org-remark-global-tracking.el
+++ b/org-remark-global-tracking.el
@@ -32,7 +32,7 @@
 (declare-function org-remark-mode "org-remark")
 
 (defcustom org-remark-notes-file-name "marginalia.org"
-  "Define the file path to store the location of highlights and write annotations.
+  "Name of the file wher we store highlights and marginal notes.
 It can be either a string or function.
 
 If it is a string, it should be a file path to the marginal notes
@@ -50,6 +50,7 @@ suffix to the file name without the extension."
           (function org-remark-notes-file-name-function)))
 
 (defvaralias 'org-remark-notes-file-path 'org-remark-notes-file-name)
+
 (make-obsolete-variable
  'org-remark-notes-file-path 'org-remark-notes-file-name "0.2.0")
 
@@ -76,15 +77,16 @@ readable, the function automatically activates `org-remark'."
   "Return a marginal notes file name for the current buffer.
 
 This is the default function for the customizing variable
-`org-remark-notes-file-path' for its funciton option.
+`org-remark-notes-file-name' for its funciton option.
 
-When the current buffer is visiting a FILE, the name of marginal
+When the current buffer is visiting a file, the name of marginal
 notes file will be \"FILE-notes.org\", adding \"-notes.org\" as a
 suffix to the file name without the extension."
   (concat (file-name-sans-extension (buffer-file-name)) "-notes.org"))
 
 (defalias
   'org-remark-notes-file-path-function 'org-remark-notes-file-name-function)
+
 (make-obsolete
  'org-remark-notes-file-path-function 'org-remark-notes-file-name-function "0.2.0" )
 
@@ -100,7 +102,7 @@ This function is meant to be addd to `find-file-hook' by
       (org-remark-mode +1))))
 
 (defun org-remark-notes-get-file-name ()
-  "Return the file path to the marginal notes for current buffer.
+  "Return the name of marginal notes file for current buffer.
 This function looks at customization variable
 `org-remark-notes-file-path'.  If it is a string, return it as
 the file path.  If it is a function, evaluate it to return the

--- a/org-remark-global-tracking.el
+++ b/org-remark-global-tracking.el
@@ -32,7 +32,7 @@
 (declare-function org-remark-mode "org-remark")
 
 (defcustom org-remark-notes-file-name "marginalia.org"
-  "Name of the file wher we store highlights and marginal notes.
+  "Name of the file where we store highlights and marginal notes.
 It can be either a string or function.
 
 If it is a string, it should be a file path to the marginal notes
@@ -77,7 +77,7 @@ readable, the function automatically activates `org-remark'."
   "Return a marginal notes file name for the current buffer.
 
 This is the default function for the customizing variable
-`org-remark-notes-file-name' for its funciton option.
+`org-remark-notes-file-name' for its function option.
 
 When the current buffer is visiting a file, the name of marginal
 notes file will be \"FILE-notes.org\", adding \"-notes.org\" as a
@@ -94,7 +94,7 @@ suffix to the file name without the extension."
 
 (defun org-remark-auto-on ()
   "Automatically activates `org-remark-mode' for current buffer when relevant.
-This function is meant to be addd to `find-file-hook' by
+This function is meant to be added to `find-file-hook' by
 `org-remark-global-tracking-mode'."
   (when-let (notes-file (org-remark-notes-get-file-name))
     (when (file-readable-p notes-file)

--- a/org-remark.el
+++ b/org-remark.el
@@ -6,7 +6,7 @@
 ;; URL: https://github.com/nobiot/org-remark
 ;; Version: 0.2.0
 ;; Created: 22 December 2020
-;; Last modified: 04 February 2022
+;; Last modified: 05 February 2022
 ;; Package-Requires: ((emacs "27.1") (org "9.4"))
 ;; Keywords: org-mode, annotation, writing, note-taking, marginal-notes
 
@@ -104,7 +104,7 @@ It is a local variable and is a list of overlays.  Each overlay
 represents a highlighted text region.
 
 On `save-buffer' each highlight will be saved in the notes file at
-the path returned by `org-remark-notes-get-file-path'.")
+the path returned by `org-remark-notes-get-file-name'.")
 
 (defvar-local org-remark-highlights-hidden nil
   "Keep hidden/shown state of the highlights in current buffer.")
@@ -330,7 +330,7 @@ region.
 
 A Org headline entry for the highlght will be created in the
 marginal notes file specified by
-`org-remark-notes-get-file-path'.  If the file does not exist
+`org-remark-notes-get-file-name'.  If the file does not exist
 yet, it will be created.
 
 When this function is called from Elisp, ID can be
@@ -647,7 +647,7 @@ marginal notes file.  The expected values are nil, :load and
 :change.
 
 A Org headline entry for the highlght will be created in the
-marginal notes file specified by `org-remark-notes-get-file-path'.
+marginal notes file specified by `org-remark-notes-get-file-name'.
 If the file does not exist yet, it will be created.
 
 When this function is called from Elisp, ID can be optionally
@@ -743,7 +743,7 @@ source with using ORGID."
          (id (plist-get props 'org-remark-id))
          (text (org-with-wide-buffer (buffer-substring-no-properties beg end)))
          (orgid (org-remark-highlight-get-org-id beg))
-         (notes-buf (find-file-noselect (org-remark-notes-get-file-path)))
+         (notes-buf (find-file-noselect (org-remark-notes-get-file-name)))
          (line-num (org-current-line beg)))
     (with-current-buffer notes-buf
       (when (featurep 'org-remark-convert-legacy) (org-remark-convert-legacy-data))
@@ -850,7 +850,7 @@ notes file of the current buffer.  This function ensures there is
 only one of the marginal notes buffer per session."
   ;; Compare the target marginal notes buffer and current marginal notes buffer.
   ;; For the latter, we need the base buffer of an indirect buffer.
-  (let ((cbuf (find-file-noselect (org-remark-notes-get-file-path)))
+  (let ((cbuf (find-file-noselect (org-remark-notes-get-file-name)))
         (ibuf (when (buffer-live-p org-remark-last-notes-buffer)
                 org-remark-last-notes-buffer)))
     (unless (eq (buffer-base-buffer ibuf) cbuf)
@@ -920,10 +920,10 @@ load the highlights"
 
 (defun org-remark-highlights-get ()
   "Return a list of highlights from the marginal notes file path.
-The file path is returned by `org-remark-notes-get-file-path'.
+The file path is returned by `org-remark-notes-get-file-name'.
 Each highlight is a list in the following structure:
     (ID (BEG . END) LABEL)"
-  (when-let ((notes-buf (find-file-noselect (org-remark-notes-get-file-path)))
+  (when-let ((notes-buf (find-file-noselect (org-remark-notes-get-file-name)))
              (source-path (org-remark-source-path (buffer-file-name))))
     ;; TODO check if there is any relevant notes for the current file
     ;; This can be used for adding icon to the highlight
@@ -1086,5 +1086,5 @@ function extends the behavior and looks for the word at point"
 ;;; org-remark.el ends here
 
 ;; Local Variables:
-;; org-remark-notes-file-path: "README.org"
+;; org-remark-notes-file-name: "README.org"
 ;; End:

--- a/org-remark.el
+++ b/org-remark.el
@@ -86,8 +86,8 @@ of the source file.  The `default-directory' is set to the
 directory where the marginal notes file resides.
 
 This means that when the \"Relative file name\" option is
-selected, the source file name will be relative to the marginal
-notes file."
+selected, the source file name recorded in the marginal notes
+file will be relative to it."
   :type '(choice
           (const :tag "Relative file name" file-relative-name)
           (const :tag "Abbreviated absolute file name" abbreviate-file-name)
@@ -337,7 +337,7 @@ When this function is used interactively, it will generate a new
 ID, always assuming it is working on a new highlighted text
 region.
 
-A Org headline entry for the highlght will be created in the
+A Org headline entry for the highlight will be created in the
 marginal notes file specified by
 `org-remark-notes-get-file-name'.  If the file does not exist
 yet, it will be created.
@@ -409,7 +409,7 @@ You can customize the name of the marginal notes buffer with
 By default, the cursor will go to the marginal notes buffer for
 further editing.  When VIEW-ONLY is non-nil \(e.g. by passing a
 universal argument with \\[universal-argument]\), you can display
-the marginal notes buffer with the cursour remaining in the
+the marginal notes buffer with the cursor remaining in the
 current buffer.
 
 This function ensures that there is only one cloned buffer for
@@ -577,7 +577,7 @@ This command is identical with passing a universal argument to
 NEXT must be either non-nil or nil.
 When non-nil it's for the next; for nil, prev.
 
-This function is internal only and meant to be used by interctive
+This function is internal only and meant to be used by interactive
 commands such as `org-remark-next' and `org-remark-prev'.
 
 Return t if the cursor has moved to next/prev.
@@ -655,7 +655,7 @@ MODE determines whether or not highlight is to be saved in the
 marginal notes file.  The expected values are nil, :load and
 :change.
 
-A Org headline entry for the highlght will be created in the
+A Org headline entry for the highlight will be created in the
 marginal notes file specified by `org-remark-notes-get-file-name'.
 If the file does not exist yet, it will be created.
 
@@ -740,8 +740,8 @@ update, the headline text will be kept intact, because the user
 might have changed it to their needs.
 
 This function will also add a normal file link as property
-\"org-remark-lilnk\" of the H2 headline entry back to the current
-buffer with serach option \"::line-number\".
+\"org-remark-link\" of the H2 headline entry back to the current
+buffer with search option \"::line-number\".
 
 ORGID can be passed to this function.  If user option
 `org-remark-use-org-id' is non-nil, this function will add an
@@ -854,7 +854,7 @@ Do you really want to delete the notes?"))
 
 (defun org-remark-notes-buffer-get-or-create ()
   "Return marginal notes buffer.
-It's a cloned indirect buffer of a buffer visiting the margina
+It's a cloned indirect buffer of a buffer visiting the marginal
 notes file of the current buffer.  This function ensures there is
 only one of the marginal notes buffer per session."
   ;; Compare the target marginal notes buffer and current marginal notes buffer.
@@ -968,7 +968,7 @@ Each highlight is a list in the following structure:
            highlights))))))
 
 (defun org-remark-highlights-get-positions (&optional reverse)
-  "Return list of the beggining point of all visible highlights in this buffer.
+  "Return list of the beginning point of all visible highlights in this buffer.
 By default, the list is in ascending order.  If REVERSE is
 non-nil, return list in the descending order.
 
@@ -1034,11 +1034,11 @@ the show/hide state."
     (setq org-remark-highlights-hidden nil)))
 
 (defun org-remark-highlights-housekeep ()
-  "Housekeep the internal variable `org-remark-highlights'.
+  "House keep the internal variable `org-remark-highlights'.
 
 Return t.
 
-This is a private function; housekeep is automatically done on
+This is a private function; house keep is automatically done on
 mark, save, and remove -- before sort-highlights.
 
 Case 1. Both start and end of an overlay are identical

--- a/org-remark.el
+++ b/org-remark.el
@@ -78,7 +78,7 @@ for more detail and expected elements of the list."
 buffer with this name."
   :type 'string)
 
-(defcustom org-remark-source-file-name-function #'file-relative-name
+(defcustom org-remark-source-file-name #'file-relative-name
   "Function that return the file name to point back at the source file.
 
 The function is called with a single argument: the absolute path
@@ -94,10 +94,10 @@ file will be relative to it."
           (function :tag "Other function")))
 
 (defvaralias
-  'org-remark-source-path-function 'org-remark-source-file-name-function)
+  'org-remark-source-path-function 'org-remark-source-file-name)
 
 (make-obsolete-variable
- 'org-remark-source-path-function 'org-remark-source-file-name-function "0.2.0")
+ 'org-remark-source-path-function 'org-remark-source-file-name "0.2.0")
 
 (defcustom org-remark-use-org-id nil
   "Define if Org-remark use Org-ID to link back to the main note."
@@ -747,7 +747,7 @@ ORGID can be passed to this function.  If user option
 `org-remark-use-org-id' is non-nil, this function will add an
 Org-ID link in the body text of the headline, linking back to the
 source with using ORGID."
-  (let* ((filename (org-remark-source-file-name filename))
+  (let* ((filename (org-remark-source-get-file-name filename))
          (id (plist-get props 'org-remark-id))
          (text (org-with-wide-buffer (buffer-substring-no-properties beg end)))
          (orgid (org-remark-highlight-get-org-id beg))
@@ -933,7 +933,7 @@ The file name is returned by `org-remark-notes-get-file-name'.
 Each highlight is a list in the following structure:
     (ID (BEG . END) LABEL)"
   (when-let ((notes-buf (find-file-noselect (org-remark-notes-get-file-name)))
-             (source-file-name (org-remark-source-file-name (buffer-file-name))))
+             (source-file-name (org-remark-source-get-file-name (buffer-file-name))))
     ;; TODO check if there is any relevant notes for the current file
     ;; This can be used for adding icon to the highlight
     (let ((highlights))
@@ -1065,7 +1065,7 @@ Case 2. The overlay points to no buffer
 
 
 ;;;;; Other utilities
-(defun org-remark-source-file-name (filename)
+(defun org-remark-source-get-file-name (filename)
   "Convert FILENAME either to absolute or relative for marginal notes files.
 Returns the standardized filename.
 
@@ -1074,7 +1074,7 @@ The current buffer is assumed to be visiting the source file.
 FILENAME should be an absolute file name of the source file."
   ;; Get the default-directory of the notes
   (with-current-buffer (find-file-noselect (org-remark-notes-get-file-name))
-    (funcall org-remark-source-file-name-function filename)))
+    (funcall org-remark-source-file-name filename)))
 
 (defun org-remark-region-or-word ()
   "Return beg and end of the active region or of the word at point.

--- a/org-remark.el
+++ b/org-remark.el
@@ -1065,10 +1065,16 @@ Case 2. The overlay points to no buffer
 
 
 ;;;;; Other utilities
-(defun org-remark-source-path (path)
-  "Convert PATH either to absolute or relative for marginal notes files.
-Returns the standardized path."
-  (funcall org-remark-source-path-function path))
+(defun org-remark-source-file-name (filename)
+  "Convert FILENAME either to absolute or relative for marginal notes files.
+Returns the standardized filename.
+
+The current buffer is assumed to be visiting the source file.
+
+FILENAME should be an absolute file name of the source file."
+  ;; Get the default-directory of the notes
+  (with-current-buffer (find-file-noselect (org-remark-notes-get-file-name))
+    (funcall org-remark-source-file-name-function filename)))
 
 (defun org-remark-region-or-word ()
   "Return beg and end of the active region or of the word at point.


### PR DESCRIPTION
Regarding user option `org-remark-notes-file-path`, the GNU convention is to
call this a "file name" rather than a "path"; "path" is only used for lists of
directories as in `load-path` (pointed out by Stefan Monnier; thank you).

To align with the GNU convention, the following changes are done.  Users should
not have to change their existing customization as the old names are aliased to
the new ones.

User option:
- org-remark-notes-file-path -> org-remark-notes-file-name
- org-remark-source-path-function -> org-remark-source-file-name

Function:
- org-remark-notes-file-path-function -> org-remark-notes-file-name-function

Private Function:
- org-remark-notes-get-file-path -> org-remark-notes-get-file-name

`org-remark-notes-file-path`, `org-remark-source-path-function`, and  `org-remark-notes-file-path-function` are used
by existing customization, thus both explicitly made obsolete and aliased to the
new file-name equivalents.