### PR TITLE
Support taking annotations and marginalia in EWW buffers.

### DIFF
--- a/org-remark-global-tracking.el
+++ b/org-remark-global-tracking.el
@@ -30,6 +30,7 @@
 ;;; Code:
 
 (declare-function org-remark-mode "org-remark")
+(declare-function org-remark-source-find-file-name "org-remark")
 
 (defvaralias 'org-remark-notes-file-path 'org-remark-notes-file-name)
 
@@ -69,7 +70,8 @@ readable, the function automatically activates `org-remark'."
   (cond
    (org-remark-global-tracking-mode
     ;; Activate
-    (add-hook 'find-file-hook #'org-remark-auto-on))
+    (progn (add-hook 'find-file-hook #'org-remark-auto-on)
+           (add-hook 'eww-after-render-hook #'org-remark-auto-on)))
    (t
     ;; Deactivate
     (remove-hook 'find-file-hook #'org-remark-auto-on))))
@@ -83,7 +85,9 @@ This is the default function for the customizing variable
 When the current buffer is visiting a file, the name of marginal
 notes file will be \"FILE-notes.org\", adding \"-notes.org\" as a
 suffix to the file name without the extension."
-  (concat (file-name-sans-extension (buffer-file-name)) "-notes.org"))
+  (concat (file-name-sans-extension
+           (file-name-nondirectory (org-remark-source-find-file-name)))
+          "-notes.org"))
 
 (defalias
   'org-remark-notes-file-path-function 'org-remark-notes-file-name-function)


### PR DESCRIPTION
EWW buffers are not associated with a file, which causes `buffer-file-name` to return nil.

This change extracts the functionality to find the source filename into a separate function. Earlier, `org-remark` used `buffer-file-name` to find the source filename.

This allows us to handle `eww-mode` within the new function (and potentially more such modes in the future).

We also add `org-remark-auto-on` to the `eww-after-render-hook` to make sure that existing annotations are loaded.

The end result is that it is now possible to annotate web-pages inside EWW.

Function introduced:
1. `org-remark-source-find-file-name` - All direct calls to `buffer-file-name` are now replaced by this function.

Functions changed:
1. `org-remark-global-tracking-mode` - `org-remark-auto-on` runs on EWW render completion.
2. `org-remark-highlight-get-title` - This function can also extract the highlight title from the EWW URL now.

## How I've tested the changes:
-    Does taking notes work in eww buffers?
    - Tested for archived urls (of the `file://` type)
    - Tested for normal urls
-    Does taking notes work for different types of web-pages?
    - URLs that end in a '/' (need special handling)
    - URLs that end in '.html'
-    Does reloading the EWW page maintain the notes?
    - Tested for archived urls
    - Tested for normal urls
-    Does different kinds of highlighting work correctly?
    - Tested `org-remark-mark`
    - Tested `org-remark-mark-yellow`
    - Tested `org-remark-mark-red-line`
-    Does remark functionality work?
    - Tested `org-remark-view-next`
    - Tested `org-remark-view-prev`
    - Tested `org-remark-view`
    - Tested `org-remark-save`
    - Tested `org-remark-open`
    - Tested `org-remark-toggle`
-    Check what happens when existing notes are modified
    - Tested for archived urls
    - Tested for normal urls
-    Check what happens when new notes are added to an existing annotated web-page
    - Tested for archived urls
    - Tested for normal urls