### PR TITLE
feat: Let source file pull some additional props from the notes file

### DIFF
--- a/README.org
+++ b/README.org
@@ -118,31 +118,31 @@ This macro was inspired by [[https://github.com/jkitchin/ov-highlight][Ov-highli
 
 ** org-remark-notes-send-data
 :PROPERTIES:
-:org-remark-beg: 39420
-:org-remark-end: 39446
+:org-remark-beg: 39905
+:org-remark-end: 39931
 :org-remark-id: 4de1f10c
 :org-remark-label: nil
-:org-remark-link: [[file:org-remark.el::982]]
+:org-remark-link: [[file:org-remark.el::989]]
 :org-remark-note-body: [empty entry]
 :END:
 
 ** org-remark-highlights-load
 :PROPERTIES:
-:org-remark-beg: 39537
-:org-remark-end: 39563
+:org-remark-beg: 40022
+:org-remark-end: 40048
 :org-remark-id: bf05b18c
 :org-remark-label: nil
-:org-remark-link: [[file:org-remark.el::986]]
+:org-remark-link: [[file:org-remark.el::993]]
 :org-remark-note-body: [empty entry]
 :END:
 
 ** goto
 :PROPERTIES:
-:org-remark-beg: 33747
-:org-remark-end: 33751
+:org-remark-beg: 34151
+:org-remark-end: 34155
 :org-remark-id: 184667c4
 :org-remark-label: nil
-:org-remark-link: [[file:org-remark.el::850]]
+:org-remark-link: [[file:org-remark.el::856]]
 :org-remark-note-body: This is no longer empty.
 :END:
 This is no longer empty.

--- a/README.org
+++ b/README.org
@@ -118,31 +118,31 @@ This macro was inspired by [[https://github.com/jkitchin/ov-highlight][Ov-highli
 
 ** org-remark-notes-send-data
 :PROPERTIES:
-:org-remark-beg: 39511
-:org-remark-end: 39537
+:org-remark-beg: 39420
+:org-remark-end: 39446
 :org-remark-id: 4de1f10c
 :org-remark-label: nil
-:org-remark-link: [[file:org-remark.el::984]]
+:org-remark-link: [[file:org-remark.el::982]]
 :org-remark-note-body: [empty entry]
 :END:
 
 ** org-remark-highlights-load
 :PROPERTIES:
-:org-remark-beg: 39628
-:org-remark-end: 39654
+:org-remark-beg: 39537
+:org-remark-end: 39563
 :org-remark-id: bf05b18c
 :org-remark-label: nil
-:org-remark-link: [[file:org-remark.el::988]]
+:org-remark-link: [[file:org-remark.el::986]]
 :org-remark-note-body: [empty entry]
 :END:
 
 ** goto
 :PROPERTIES:
-:org-remark-beg: 33838
-:org-remark-end: 33842
+:org-remark-beg: 33747
+:org-remark-end: 33751
 :org-remark-id: 184667c4
 :org-remark-label: nil
-:org-remark-link: [[file:org-remark.el::852]]
+:org-remark-link: [[file:org-remark.el::850]]
 :org-remark-note-body: This is no longer empty.
 :END:
 This is no longer empty.

--- a/README.org
+++ b/README.org
@@ -110,3 +110,39 @@ This section is created by Org-remark for the source file. It serves as an examp
 ** defmacro org-remark-create
 
 This macro was inspired by [[https://github.com/jkitchin/ov-highlight][Ov-highlight]].  It's by John Kitchin (author of Org-ref). Great UX for markers with hydra. Saves the marker info and comments directly within the Org file as Base64 encoded string. It uses overlays with using ~ov~ package.
+
+* org-remark
+:PROPERTIES:
+:org-remark-file: org-remark.el
+:END:
+
+** org-remark-notes-send-data
+:PROPERTIES:
+:org-remark-beg: 39511
+:org-remark-end: 39537
+:org-remark-id: 4de1f10c
+:org-remark-label: nil
+:org-remark-link: [[file:org-remark.el::984]]
+:org-remark-note-body: [empty entry]
+:END:
+
+** org-remark-highlights-load
+:PROPERTIES:
+:org-remark-beg: 39628
+:org-remark-end: 39654
+:org-remark-id: bf05b18c
+:org-remark-label: nil
+:org-remark-link: [[file:org-remark.el::988]]
+:org-remark-note-body: [empty entry]
+:END:
+
+** goto
+:PROPERTIES:
+:org-remark-beg: 33838
+:org-remark-end: 33842
+:org-remark-id: 184667c4
+:org-remark-label: nil
+:org-remark-link: [[file:org-remark.el::852]]
+:org-remark-note-body: This is no longer empty.
+:END:
+This is no longer empty.

--- a/org-remark.el
+++ b/org-remark.el
@@ -341,7 +341,7 @@ recommended to turn it on as part of Emacs initialization.
 
 (add-to-list 'org-remark-available-pens #'org-remark-mark)
 ;;;###autoload
-(defun org-remark-mark (beg end &optional id text mode)
+(defun org-remark-mark (beg end &optional id mode)
   "Apply face `org-remark-highlighter' to the region between BEG and END.
 
 When this function is used interactively, it will generate a new
@@ -362,18 +362,14 @@ back to the database.
 MODE is also an argument which can be passed from Elisp.  It
 determines whether or not highlight is to be saved in the
 marginal notes file.  The expected values are nil, :load and
-:change.
-
-TEXT is an excerpt of the body text of the marginal note (for
-:load and :change modes only)."
+:change."
   (interactive (org-remark-region-or-word))
   ;; FIXME
   ;; Adding "nil" is different to removing a prop
   ;; This will do for now
   (org-remark-highlight-mark beg end id mode
                              nil nil
-                             (list 'org-remark-label "nil"
-                                   'help-echo text)))
+                             (list 'org-remark-label "nil")))
 
 (when org-remark-create-default-pen-set
   ;; Create default pen set.
@@ -709,8 +705,10 @@ to the database."
                                         beg end
                                         (overlay-properties ov)
                                         (org-remark-highlight-get-title))
+              ;;; Get props for create and change any way
            (message "org-remark: Highlights not saved; buffer is not visiting a file")))
        ;;; on load, send data once from notes to source
+
        (when (eq mode :load)
          (org-remark-notes-communicate-with-source filename id)))))
   ;;; for on-going communication from notes to source, after-save-hook.
@@ -1008,7 +1006,8 @@ load the highlights"
       (let ((fn (intern (concat "org-remark-mark-" label))))
         (unless (functionp fn) (setq fn #'org-remark-mark))
         (funcall fn beg end id :load)
-        ;; TODO Generalize. TEXT should not be the fixed property.
+        ;; TODO Generalize the part that updates properties.
+        ;; :body should not be the fixed property.
         ;; '(:text (val . fn) :prop1 (val . fn) :prop2 (val .fn))
         ;; (dolist list)
         (let ((ov (org-remark-find-overlay-at-point beg)))

--- a/org-remark.el
+++ b/org-remark.el
@@ -6,7 +6,7 @@
 ;; URL: https://github.com/nobiot/org-remark
 ;; Version: 1.0.5
 ;; Created: 22 December 2020
-;; Last modified: 24 December 2022
+;; Last modified: 25 December 2022
 ;; Package-Requires: ((emacs "27.1") (org "9.4"))
 ;; Keywords: org-mode, annotation, note-taking, marginal-notes, wp,
 
@@ -167,7 +167,7 @@ property names with \"org-remark-\" or use \"CATEGORY\"."
     `(progn
        ;; Define custom pen function
        (defun ,(intern (format "org-remark-mark-%s" label))
-           (beg end &optional id mode text)
+           (beg end &optional id mode)
          ,(format "Apply the following face to the region selected by BEG and END.
 
 %s
@@ -190,10 +190,7 @@ When the pen itself defines the help-echo property, it will have
 the priority over the excerpt of the marginal notes."
                   (or face "`org-remark-highlighter'") properties)
          (interactive (org-remark-region-or-word))
-         (let ((properties ,properties))
-           (unless (member 'help-echo properties)
-             (setq properties (append properties (list 'help-echo text))))
-           (org-remark-highlight-mark beg end id mode ,label ,face properties)))
+         (org-remark-highlight-mark beg end id mode ,label ,face ,properties))
 
        ;; Register to `org-remark-available-pens'
        (add-to-list 'org-remark-available-pens
@@ -344,7 +341,7 @@ recommended to turn it on as part of Emacs initialization.
 
 (add-to-list 'org-remark-available-pens #'org-remark-mark)
 ;;;###autoload
-(defun org-remark-mark (beg end &optional id mode text)
+(defun org-remark-mark (beg end &optional id text mode)
   "Apply face `org-remark-highlighter' to the region between BEG and END.
 
 When this function is used interactively, it will generate a new
@@ -534,12 +531,11 @@ from."
               (id (overlay-get ov 'org-remark-id))
               (beg (overlay-start ov))
               (end (overlay-end ov)))
-    (let* ((text (overlay-get ov 'help-echo))
-           (new-pen (if pen pen
+    (let ((new-pen (if pen pen
                      (intern
                       (completing-read "Which pen?:" org-remark-available-pens)))))
       (delete-overlay ov)
-      (funcall new-pen beg end id :change text))))
+      (funcall new-pen beg end id :change))))
 
 (defun org-remark-remove (point &optional delete)
   "Remove the highlight at POINT.
@@ -706,17 +702,43 @@ to the database."
      (push ov org-remark-highlights)
      ;; for mode, nil and :change result in saving the highlight.  :load
      ;; bypasses save.
-     (unless (eq mode :load)
-       (let ((filename (org-remark-source-find-file-name)))
+     (let ((filename (org-remark-source-find-file-name)))
+       (unless (eq mode :load)
          (if filename
              (org-remark-highlight-save filename
                                         beg end
                                         (overlay-properties ov)
                                         (org-remark-highlight-get-title))
-           (message "org-remark: Highlights not saved; buffer is not visiting a file"))))))
+           (message "org-remark: Highlights not saved; buffer is not visiting a file")))
+       ;;; on load, send data once from notes to source
+       (when (eq mode :load)
+         (org-remark-notes-communicate-with-source filename id)))))
+  ;;; for on-going communication from notes to source, after-save-hook.
+  (let ((notes-buf (find-file-noselect (org-remark-notes-get-file-name))))
+    (with-current-buffer notes-buf
+        ;;; think of the case when source = notes files?
+      (add-hook 'after-save-hook #'org-remark-notes-send-data nil :local)))
   (deactivate-mark)
   (org-remark-highlights-housekeep)
   (org-remark-highlights-sort))
+
+(defun org-remark-notes-communicate-with-source (filename id)
+  "Send data for the marginal notes for ID.
+Assume the current buffer is the source buffer."
+  ;;; Add local hook to the notes buffer so that it can communicate data
+  ;;; to the source buffer upon save.
+  (let ((notes-buf (find-file-noselect (org-remark-notes-get-file-name))))
+    (with-current-buffer notes-buf
+      ;;; on load, send data once
+      (org-with-wide-buffer
+       ;;; File must exist already; this is not to create
+       (let ((file-headline (org-find-property
+                             org-remark-prop-source-file
+                             (org-remark-source-get-file-name filename)))
+             (id-headline (org-find-property org-remark-prop-id id)))
+         (goto-char file-headline)
+         (goto-char id-headline)
+         (message (concat "text" (org-remark-highlight-get-text))))))))
 
 (defun org-remark-highlight-get-title ()
   "Return the title of the current buffer.
@@ -959,6 +981,10 @@ drawer."
 ;;;;; org-remark-highlights
 ;;    Work on all the highlights in the current buffer
 
+(defun org-remark-notes-send-data ()
+  ;; TODO.  Think of the case when source = notes files
+  (message "Sending"))
+
 (defun org-remark-highlights-load ()
   "Visit `org-remark-notes-file' & load the saved highlights onto current buffer.
 If there is no highlights or annotations for current buffer,
@@ -973,20 +999,29 @@ Otherwise, do not forget to turn on `org-remark-mode' manually to
 load the highlights"
   ;; Loop highlights and add them to the current buffer
   (dolist (highlight (org-remark-highlights-get))
-    (let ((id (car highlight))
-          (beg (caadr highlight))
-          (end (cdadr highlight))
-          (label (caddr highlight))
-          (text (cadddr highlight)))
+    (let* ((id (plist-get highlight :id))
+           (location (plist-get highlight :location))
+           (beg (car location))
+           (end (cdr location))
+           (label (plist-get highlight :label))
+           (props (plist-get highlight :props)))
       (let ((fn (intern (concat "org-remark-mark-" label))))
         (unless (functionp fn) (setq fn #'org-remark-mark))
-        (funcall fn beg end id :load text)))))
+        (funcall fn beg end id :load)
+        ;; TODO Generalize. TEXT should not be the fixed property.
+        ;; '(:text (val . fn) :prop1 (val . fn) :prop2 (val .fn))
+        ;; (dolist list)
+        (let ((ov (org-remark-find-overlay-at-point beg)))
+          (unless (overlay-get ov 'help-echo)
+            (overlay-put ov 'help-echo (plist-get props :body)))
+          (overlay-put ov 'org-remark-note-body
+                       (plist-get props :body)))))))
 
 (defun org-remark-highlights-get ()
   "Return a list of highlights from the marginal notes file.
 The file name is returned by `org-remark-notes-get-file-name'.
-Each highlight is a list in the following structure:
-    (ID (BEG . END) LABEL TEXT)"
+Each highlight is a property list in the following properties:
+    (:id ID :location (BEG . END) :label LABEL :props '(PROPERTIES)"
   ;; Set source-file-name first, as `find-file-noselect' will set the
   ;; current-buffer to source-file-name. Issue #39 FIXME: A way to make
   ;; this sequence agnostic is preferred, if there is a function that
@@ -1023,10 +1058,10 @@ Each highlight is a list in the following structure:
                                 (org-entry-get (point)
                                                org-remark-prop-source-end)))
                           (text (org-remark-highlight-get-text)))
-                 (push (list id
-                             (cons beg end)
-                             (org-entry-get (point) "org-remark-label")
-                             text)
+                 (push (list :id id
+                             :location (cons beg end)
+                             :label    (org-entry-get (point) "org-remark-label")
+                             :props    (list :body text))
                        highlights))))
            highlights))))))
 


### PR DESCRIPTION
PR #32 adds a nice feature of showing excerpts of the notes' body as a tooltip/help-echo. This has opened up a new avenue to allow Org-remark communicate some notes' properties to from notes file to its source file. 

However, this PR also added an additional argument TEXT to the main function `org-remark-mark`. We should prefer to keep the key function's signature unchanged.

In addition, there should be a standard ways for notes and source files to communicate -- especially on change/save of notes file. 

Still WIP, but this PR quickly removes the TEXT arg in `org-remark-mark` and its friends (`org-remark-create` and `org-remark-change`) and yet retains the tooltip/help-echo.