### PR TITLE
Rounding off "notes-sync" feature

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,57 @@
+[More recent changes v1.0.0 are in NEWS file]
+
+Version 0.2.0
+  - add: org-remark-delete
+  - rm: Adding Org-ID automatically to file level when file is empty
+
+Version 0.1.0
+* Features & additions
+
+  - docs: comprehensive user manual (online - Info to be added on ELPA release)
+
+  - feat: org-remark-create macro to let users create their own custom pens
+
+  - feat: minor-mode menu for menu-bar-mode
+
+          This works as mouse context-menu for the new context-menu-mode (>=
+          Emacs 28)
+
+  - add: browse-next/prev: move and display next/prev marginal notes at the same
+         time
+
+  - add: view/open to display side-window by default (user option)
+
+  - add: org-remark-link property in marginal notes file with ::line-number
+         search option
+
+  - feat: org-remark-legacy-convert as a separate feature
+
+          This is for automatically converting legacy Org-marginalia file to
+          Org-remark.
+
+  - feat: Legacy data facility with org-remark-tracking
+
+* Changes
+
+  - chg: `remove' (and delete) only removes one highlight at a time instead of
+         remove all at point
+
+  - chg: Save marginal notes on `mark' instead of wainting for `save'
+
+  - chg: define org-remark-mark explicitly for autoload cookie
+
+  - chg: `org-remark-view' and `org-remark-open'. View will stay in the
+          current main note; open will move the cursor to the marginal notes
+          buffer for further editing.
+
+  - chg: When updating the existing headline and position properties, don't
+         update the headline text when it already exists. Let the user decide
+         how to manage headlines.
+
+  - doc: copyright assignment to FSF; copyright years
+
+* Alpha
+
 ** 0.0.6
 
 Feature:

--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,6 @@
 Version 1.1.0-rc -- Current development version
-* Features:
+
+  Features:
 
   - feat: notes-and-source sync
           Previously, Org-remark was designed to create/update/delete
@@ -58,7 +59,7 @@ Version 1.1.0-rc -- Current development version
          Hook run when a note buffer is opened/visited. The current
          buffer is the note buffer.
 
-* Fixes:
+  Fixes:
 
   - refactor: change the default colors of yellow pen #52
          This is to cater to users who have dark theme that may render
@@ -160,53 +161,4 @@ Version 1.0.0
          returns a file name like this: "FILE-notes.org" by adding
          "-notes.org" as a suffix to the file name without the extension.
 
-
-Version 0.2.0
-  - add: org-remark-delete
-  - rm: Adding Org-ID automatically to file level when file is empty
-
-Version 0.1.0
-* Features & additions
-
-  - docs: comprehensive user manual (online - Info to be added on ELPA release)
-
-  - feat: org-remark-create macro to let users create their own custom pens
-
-  - feat: minor-mode menu for menu-bar-mode
-
-          This works as mouse context-menu for the new context-menu-mode (>=
-          Emacs 28)
-
-  - add: browse-next/prev: move and display next/prev marginal notes at the same
-         time
-
-  - add: view/open to display side-window by default (user option)
-
-  - add: org-remark-link property in marginal notes file with ::line-number
-         search option
-
-  - feat: org-remark-legacy-convert as a separate feature
-
-          This is for automatically converting legacy Org-marginalia file to
-          Org-remark.
-
-  - feat: Legacy data facility with org-remark-tracking
-
-* Changes
-
-  - chg: `remove' (and delete) only removes one highlight at a time instead of
-         remove all at point
-
-  - chg: Save marginal notes on `mark' instead of wainting for `save'
-
-  - chg: define org-remark-mark explicitly for autoload cookie
-
-  - chg: `org-remark-view' and `org-remark-open'. View will stay in the
-          current main note; open will move the cursor to the marginal notes
-          buffer for further editing.
-
-  - chg: When updating the existing headline and position properties, don't
-         update the headline text when it already exists. Let the user decide
-         how to manage headlines.
-
-  - doc: copyright assignment to FSF; copyright years
+[Older changes before v1.0.0 are in CHANGELOG file]

--- a/NEWS
+++ b/NEWS
@@ -1,7 +1,90 @@
-Development
+Version 1.1.0-rc -- Current development version
+* Features:
+
+  - feat: notes-and-source sync
+          Previously, Org-remark was designed to create/update/delete
+          highlights from the source buffer to its marginal notes
+          buffer; this was always one-way from the source to the notes.
+
+          Now we have implemented the updating process in the other
+          direction from the notes to source.
+
+          Functionally, we currently have echo-text/tooltip containing
+          an excerpt from the body of notes from the notes buffer
+          (thanks to @mooseyboots).
+
+          Other than this additional feature, there should be no visible
+          change for end users.  The update should all happen
+          transparently behind the scenes with no to little change for
+          end users of Org-remark.
+
+  - feat: echo-text update from the marginal notes to the source buffer
+          This is a code contribution by marty hiatt (@mooseyboots).  He
+          has done FSF copyright assignment in July, 2022.
+
+          Now the source buffer can Display annotation text as help-echo
+          or tooltip. Thank you, @mooseyboots.
+
+          This has opened up an avenue to implement "notes sync" feature
+          which updates select elements of marginal notes buffer back
+          into the source buffer for highlight overlays.
+
+  - feat: Extend support for non-file-visiting buffer
+          We now have an approach to extend Org-remark to support
+          non-file-visiting buffers of various modes.  Currently it is
+          assumed that the support is to be implemented per mode
+          basis. We have support for EWW with 'org-remark-eww-mode' and
+          its dedicated file and feature 'org-remark-eww'. Refer to its
+          implementation as a reference as to how this approach is
+          currently practiced.
+
+  - feat: Global minor mode org-remark-eww-mode
+          Support taking annotations in eww buffers for websites A new
+          feature contributed by Vedang Manerikar (@vedang).  He has
+          completed FSF paperwork in May, 2022 and received a PDF
+          regarding the same from the FSF.
+
+          This has opened up a big new avenue to support highlights in
+          non-file visiting buffers. Thank you @vedang.
+
+          EWW support is modularized in a separate file
+          'org-remark-eww.el'.
+
+          org-remark-link: prop for EWW
+          Now 'org-remark-link' property in the marginal notes buffer
+          contains the URL that you can follow for the source website.
+
+  - add: org-remark-open-hook #40
+         Hook run when a note buffer is opened/visited. The current
+         buffer is the note buffer.
+
+* Fixes:
+
+  - refactor: change the default colors of yellow pen #52
+         This is to cater to users who have dark theme that may render
+         the highlighted text illegible due to the default background
+         color of yellow.
+
   - fix: Text cut off in notes if the highlight spans across two lines #56
-    Thanks to GitHub user @sati-bodhi for reporting and suggesting a fix
-    (code implemented by nobiot)
+         Thanks to GitHub user @sati-bodhi for reporting and suggesting a fix
+         (code implemented by nobiot). Thank you @sati-bodhi.
+
+  - fix: issue #44 change CATEGORY
+         Now CATEGORY property from the highlight can be properly
+         deleted if a new pen does not have CATEGORY.
+
+  - fix: case for highlight-get-text empty notes at the bottom of buffer
+
+  - fix: text-property org-remark-label to be symbol
+         Fixes the error when you do 'describe-text-properties' on the
+         highlight overlay
+
+  - fix: move org-remark-source-find-file-name to tracking
+         After EWW support, 'org-remark-source-get-file-name' is now
+         moved to 'org-remark-global-tracking.el' file
+
+  - fix: source-file-name incorrect issue #39
+         PR #38 by Nan Jun Jie (@nanjj).  Thank you @nanjj.
 
 Version 1.0.5
   - fix #28 toggle causes error on saving highlights

--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,9 @@
+Development
+  - fix: Text cut off in notes if the highlight spans across two lines #56
+    Thanks to GitHub user @sati-bodhi for reporting and suggesting a fix
+    (code implemented by nobiot)
 
-
-Version 1.0.5 - Current
+Version 1.0.5
   - fix #28 toggle causes error on saving highlights
   - fix #39 source-file-name incorrect issue
 

--- a/README.org
+++ b/README.org
@@ -90,9 +90,11 @@ Thank you.
 - ~echo-text~ update from the marginal notes to the source buffer by marty hiatt (@mooseyboots)
 - Support for websites with ~eww-mode~ by Vedang Manerikar (@vedang)
 
-** Bug fixes: Nan Jun Jie (@nanjj), @sati-bodhi
+** Bug fixes:
+Nan Jun Jie (@nanjj), @sgati-bodhi
 
-** Documentation: @randomwangran
+** Documentation:
+@randomwangran
 
 
 * License

--- a/README.org
+++ b/README.org
@@ -75,6 +75,13 @@ Below are example keybindings you might like to consider:
     (define-key org-remark-mode-map (kbd "C-c n [") #'org-remark-view-prev)
     (define-key org-remark-mode-map (kbd "C-c n r") #'org-remark-remove))
 #+end_src
+* Features
+
+- Highlight and annotate any text file. The highlights and notes are kepted in an Org file as the plain text database. This lets you easily manage your marginal notes and use the built-in Org fecilities on them -- e.g. create a sparse tree based on the category of the notes
+
+- Have the same highlighting and annotating functionality for websites when you use EWW to browse them (new in latest [[https://elpa.gnu.org/devel/org-remark.html][GNU-devel ELPA]] and is planned to be part of v1.1.0.)
+
+- Create your your own highlighter pens with different colors, type (e.g. underline, squiggle, etc. optionally with Org's category for search and filter on your highlights and notes)
 
 * Contributing and Feedback
 

--- a/README.org
+++ b/README.org
@@ -4,25 +4,14 @@
 #+html: <a href="https://www.gnu.org/software/emacs/"><img alt="GNU Emacs" src="https://img.shields.io/static/v1?logo=gnuemacs&logoColor=fafafa&label=Made%20for&message=GNU%20Emacs&color=7F5AB6&style=flat"/></a>
 #+html: <img alt="GPLv3" src="https://img.shields.io/badge/License-GPLv3-blue.svg">
 
-* ❦❦❦ IMPORTANT NOTICE ❦❦❦ :noexport:
+* Breaking Changes :noexport:
 
-[This notice written on 18 January 2022]
-
-Happy 2022!
-
-I have changed the name of the project and package to "*Org-remark*" from Org-marginalia.
-
-If you are using Org-marginalia now, there are breaking changes. This package includes the feature that automatically converts the old Org-marginalia data into the new Org-remark data. Add ~org-remark-convert-legacy~ feature like this:
-
-#+begin_src elisp
-  (require 'org-remark-convert-legacy)
-#+end_src
-
-This feature is designed to work automatically and transparently to you, meaning you should not have to do anything, as long as you did not customize ~org-marginala-notes-file-path~. If you did, you also need to customize ~org-remark-notes-file-path~. You can also manually do data conversion if you wish. For more detail, refer to the docstring of function ~org-remark-convert-legacy-data~.
+- [18 January 2022] Package name change from Org-marginalia to Org-remark. See [[https://github.com/nobiot/org-remark/issues/11][detail on data conversion]].
 
 * Introduction
 
-Org-remark lets you highlight and annotate any text file with using Org mode.
+Org-remark lets you highlight and annotate text files and websites with
+using Org mode.
 
 A user manual is available [[https://nobiot.github.io/org-remark/][online]] or Emacs in-system as an Info node `(org-remark)': (~C-h i~ and find the =Org-remark= node).
 
@@ -95,6 +84,16 @@ Create issues, discussion, and/or pull requests in the GitHub repository. All we
 Org-remark is available on GNU ELPA and thus copyrighted by the [[http://fsf.org][Free Software Foundation]] (FSF). This means that anyone who is making a substantive code contribution will need to "assign the copyright for your contributions to the FSF so that they can be included in GNU Emacs" ([[https://orgmode.org/contribute.html#copyright][Org Mode website]]).
 
 Thank you.
+
+* Contributors
+** New features
+- ~echo-text~ update from the marginal notes to the source buffer by marty hiatt (@mooseyboots)
+- Support for websites with ~eww-mode~ by Vedang Manerikar (@vedang)
+
+** Bug fixes: Nan Jun Jie (@nanjj), @sati-bodhi
+
+** Documentation: @randomwangran
+
 
 * License
 

--- a/README.org
+++ b/README.org
@@ -96,7 +96,6 @@ Nan Jun Jie (@nanjj), @sgati-bodhi
 ** Documentation:
 @randomwangran
 
-
 * License
 
 This work is licensed under a GPLv3 license. For a full copy of the license, refer to [[./LICENSE][LICENSE]].
@@ -111,15 +110,3 @@ This section is created by Org-remark for the source file. It serves as an examp
 ** defmacro org-remark-create
 
 This macro was inspired by [[https://github.com/jkitchin/ov-highlight][Ov-highlight]].  It's by John Kitchin (author of Org-ref). Great UX for markers with hydra. Saves the marker info and comments directly within the Org file as Base64 encoded string. It uses overlays with using ~ov~ package.
-
-* org-remark
-:PROPERTIES:
-:org-remark-file: org-remark.el
-:END:
-
-** org-remark-notes-send-data
-
-** org-remark-highlights-load
-
-** goto
-This is no longer empty.

--- a/README.org
+++ b/README.org
@@ -6,7 +6,7 @@
 
 * Breaking Changes :noexport:
 
-- [18 January 2022] Package name change from Org-marginalia to Org-remark. See [[https://github.com/nobiot/org-remark/issues/11][detail on data conversion]].
+- [18 January 2022] Package name change from Org-marginalia to Org-remark. See [[https://github.com/nobiot/org-remark/issues/11][detail on data conversion]]. In most cases, no action is required for you.
 
 * Introduction
 

--- a/README.org
+++ b/README.org
@@ -11,7 +11,9 @@
 * Introduction
 
 Org-remark lets you highlight and annotate text files and websites with
-using Org mode.
+using Org mode [fn:1].
+
+[fn:1]: Feature to highlight and annotate websites is new in the latest [[https://elpa.gnu.org/devel/org-remark.html][GNU-devel ELPA]] and is planned to be part of v1.1.0.
 
 A user manual is available [[https://nobiot.github.io/org-remark/][online]] or Emacs in-system as an Info node `(org-remark)': (~C-h i~ and find the =Org-remark= node).
 
@@ -22,6 +24,14 @@ Getting Started in the user manual will get you started in 5 minutes: [[https://
 For customization, refer to the customization group `org-remark' or user manual: [[https://nobiot.github.io/org-remark/#Customizing][online]] or Info node `(org-remark) Customizing'.
 
 An [[https://youtu.be/c8DHrAsFiLc][introductory video]] (8 minutes) is available on YouTube.
+
+* Features
+
+- Highlight and annotate any text file. The highlights and notes are kepted in an Org file as the plain text database. This lets you easily manage your marginal notes and use the built-in Org fecilities on them -- e.g. create a sparse tree based on the category of the notes
+
+- Have the same highlighting and annotating functionality for websites when you use EWW to browse them (new in latest [[https://elpa.gnu.org/devel/org-remark.html][GNU-devel ELPA]] and is planned to be part of v1.1.0.)
+
+- Create your your own highlighter pens with different colors, type (e.g. underline, squiggle, etc. optionally with Org's category for search and filter on your highlights and notes)
 
 * Screenshots and Videos                                           :noexport:
 
@@ -75,13 +85,6 @@ Below are example keybindings you might like to consider:
     (define-key org-remark-mode-map (kbd "C-c n [") #'org-remark-view-prev)
     (define-key org-remark-mode-map (kbd "C-c n r") #'org-remark-remove))
 #+end_src
-* Features
-
-- Highlight and annotate any text file. The highlights and notes are kepted in an Org file as the plain text database. This lets you easily manage your marginal notes and use the built-in Org fecilities on them -- e.g. create a sparse tree based on the category of the notes
-
-- Have the same highlighting and annotating functionality for websites when you use EWW to browse them (new in latest [[https://elpa.gnu.org/devel/org-remark.html][GNU-devel ELPA]] and is planned to be part of v1.1.0.)
-
-- Create your your own highlighter pens with different colors, type (e.g. underline, squiggle, etc. optionally with Org's category for search and filter on your highlights and notes)
 
 * Contributing and Feedback
 
@@ -92,14 +95,14 @@ Org-remark is available on GNU ELPA and thus copyrighted by the [[http://fsf.org
 Thank you.
 
 * Contributors
-** New features
+- New features ::
 - ~echo-text~ update from the marginal notes to the source buffer by marty hiatt (@mooseyboots)
 - Support for websites with ~eww-mode~ by Vedang Manerikar (@vedang)
 
-** Bug fixes:
+- Bug fixes ::
 Nan Jun Jie (@nanjj), @sgati-bodhi
 
-** Documentation (including README, NEWS, CHANGELOG):
+- Documentation (including README, NEWS, CHANGELOG) ::
 @randomwangran, marty hiatt (@mooseyboots)
 
 * License

--- a/README.org
+++ b/README.org
@@ -105,6 +105,9 @@ Nan Jun Jie (@nanjj), @sgati-bodhi
 - Documentation (including README, NEWS, CHANGELOG) ::
 @randomwangran, marty hiatt (@mooseyboots)
 
+- All the comments, issues, and questions on GitHub ::
+@randomwangran, @karthink, @holtzermann17, @shombando, @magthe, @linwaytin, @rtrppl, @ryanprior, @ericsfraga, @darcamo, @zhewy, @QMeqGR, @Vidianos-Giannitsis, @AtomicNess123, @mooseyboots, @ouboub, @dian-yu-luo, @SylvianHemus, @basaran, @Ypot, @oatmealm, @sati-bodhi
+
 * License
 
 This work is licensed under a GPLv3 license. For a full copy of the license, refer to [[./LICENSE][LICENSE]].

--- a/README.org
+++ b/README.org
@@ -55,7 +55,6 @@ GNU ELPA should be already set up in your Emacs by default. If you wish to add G
 After installation, we suggest you put the setup below in your configuration.
 
 #+begin_src emacs-lisp
-  (require 'org-remark-global-tracking)
   (org-remark-global-tracking-mode +1)
 #+end_src
 
@@ -93,8 +92,8 @@ Thank you.
 ** Bug fixes:
 Nan Jun Jie (@nanjj), @sgati-bodhi
 
-** Documentation:
-@randomwangran
+** Documentation (including README, NEWS, CHANGELOG):
+@randomwangran, marty hiatt (@mooseyboots)
 
 * License
 

--- a/docs/org-remark.org
+++ b/docs/org-remark.org
@@ -56,9 +56,18 @@ GNU ELPA should be already set up in your Emacs by default. If you wish to add G
 
 After installation, we suggest you put the setup below in your configuration.
 
+#+name: basic-setup
 #+begin_src emacs-lisp
   (org-remark-global-tracking-mode +1)
+
+  ;; Optional if you would like to highlight websites via eww-mode
+  (with-eval-after-load 'eww
+    (org-remark-eww-mode +1))
 #+end_src
+
+~org-remark-global-tracking-mode~ automatically turns on ~org-remark-mode~ when you open a file or website via EWW [fn:1] that has a marginal notes file associated to it. This is useful to keep the location of your highlights correct across Emacs sessions after you shutdown Emacs.
+
+[fn:1]: Feature to highlight and annotate websites is new in latest [[https://elpa.gnu.org/devel/org-remark.html][GNU-devel ELPA]] and is planned to be part of v1.1.0.
 
 Unless you explicitly load ~org~ during Emacs initialization, we suggest to defer loading ~org-remark~ (thus there is no ~(require 'org-remark)~ in the example above). This is because it will also pull in ~org~, which can slow down initialization. You can control the timing of loading ~org-remark~ by autoloading some commands in a similar way with the example keybindings below.
 
@@ -128,6 +137,13 @@ Org-remark has a default highlighter pen function, and comes with a set of two a
 Org-remark lets you create your own custom pen functions with ~org-remark-create~. Use the yellow and red line pens as examples, and create your own. For how to do it, [[#create-custom-pens][How to Create Custom Highlighter Pens]].
 
 This is all you need to get started. For more detail, refer to the rest of this user manual, especially [[#usage][Usage]] and [[#customizing][Customizing]] sections. There is more to the commands introduced in this section and more ways in which you can customize Org-remark.
+
+** Highlight and Annotate Websites (new in latest [[https://elpa.gnu.org/devel/org-remark.html][GNU-devel ELPA]]; to be part of v1.1.0)
+
+#+cindex: Highlighting websites with EWW
+#+findex: org-remark-eww-mode
+
+~org-remark-eww-mode~ lets you highlight and annotate websites just like text files. It is a global minor mode. It does not require any additional configuration. All you need is to turn it on, visit a website with ~eww-mode~, and select text and highlight it. Refer to the example of a basic setup [[basic-setup]] given in [[#installation][Instalaltion]].
 
 * Usage
 :PROPERTIES:
@@ -222,10 +238,15 @@ In addition to the properties above that Org-remark reserves for itself, you can
 *** =*marginal-notes*= Buffer
 
 #+cindex: *marginal notes* buffer
+#+cindex: Echo text / Tool tip on the Highlight
 
 When you display the marginal notes with ~org-remark-view~ or ~org-remark-open~ for a given highlight, Org-remark creates a cloned indirect buffer visiting the marginal notes file. By default, it is a dedicated side-window opened to the left part of the current frame, and it is named =*marginal notes*=. You can change the behavior of ~display-buffer~ function and the name of the buffer ([[#customizing][Customizing]]).
 
 Org-remark displays the marginal notes buffer narrowed to the highlight the cursor is on.
+
+After all the properties, you can freely write your notes for the highlight. Once you save the notes buffer, an excerpt of the text (currently up to 200 characters) gets updated back onto the highlight in the source buffer. You can hover your mouse over the highlight to see the excerpt displayed in the echo area (bottom of the screen) of Emacs. If you have ~tooltip-mode~ mode turned on, the excerpt is displayed as a took tip for the highlight [fn:2].
+
+[fn:2]: Feature to display an excerpt of the body of marginal notes is new in latest [[https://elpa.gnu.org/devel/org-remark.html][GNU-devel ELPA]] and is planned to be part of v1.1.0.
 
 *** How to Change Where Marginal Notes File is Saved
 :PROPERTIES:
@@ -236,7 +257,7 @@ Org-remark displays the marginal notes buffer narrowed to the highlight the curs
 
 The location of the marginal notes file is specified by user option ~org-remark-notes-file-name~ and its default is "marginalia.org". This means the marginal notes file will reside in the same directory as the source files as a separate file.
 
-If you use the ~customize~ command to customize ~org-remark-notes-file-name~, you will have an option to choose a =File= or =Function= (customization group ~org-remark~). The default is =File= with the default "marginalial.org" as noted above.  Use a string to specify the single file name; you can specify a relative path like the default or an absolute path.
+If you use the ~customize~ command to customize ~org-remark-notes-file-name~, you will have an option to choose a =File= or =Function= (customization group ~org-remark~). The default is =File= with the default "marginal.org" as noted above.  Use a string to specify the single file name; you can specify a relative path like the default or an absolute path.
 
 If you would like to dynamically change the location based on the file and various different conditions, select the function as an option.  The default function is ~org-remark-notes-file-name-function~. It adds =-notes.org= as a suffix to the source file's name without the extension. For example, for a file named =my-source-file.txt=,  Org-remark will store highlights in  =my-source-file-notes.org=.  You can create your own function and use it.
 
@@ -375,6 +396,8 @@ Org-remark's user options are available in the customization group ~org-remark~.
 - Undo highlight does not undo it :: Overlays are not part of the undo list; you cannot undo highlighting. Use ~org-remark-remove~ or ~org-remark-delete~ commands instead.
 
 - Moving source files and marginal notes files :: Moving your files and remark file to another directory does not update the source paths and file names stored in the marginal notes file. One way to keep the links between the source files and marginal notes files is to use relative file names with ~org-remark-source-file-name~ (default).
+
+- With ~org-remark-eww-mode~, highlights get displaced when the website is edited and its content changes.
 
 * Credits
 

--- a/docs/org-remark.org
+++ b/docs/org-remark.org
@@ -1,7 +1,7 @@
 #+title: Org-remark User Manual
 #+author: Noboru Ota <me@nobiot.com>
 #+macro: version 1.0.x
-#+macro: modified 24 April 2022
+#+macro: modified 14 January 2023
 #+language: en
 #+export_file_name: org-remark.texi
 #+texinfo_dir_category: Emacs
@@ -57,7 +57,6 @@ GNU ELPA should be already set up in your Emacs by default. If you wish to add G
 After installation, we suggest you put the setup below in your configuration.
 
 #+begin_src emacs-lisp
-  (require 'org-remark-global-tracking)
   (org-remark-global-tracking-mode +1)
 #+end_src
 

--- a/docs/org-remark.org
+++ b/docs/org-remark.org
@@ -67,7 +67,7 @@ After installation, we suggest you put the setup below in your configuration.
 
 ~org-remark-global-tracking-mode~ automatically turns on ~org-remark-mode~ when you open a file or website via EWW [fn:1] that has a marginal notes file associated to it. This is useful to keep the location of your highlights correct across Emacs sessions after you shutdown Emacs.
 
-[fn:1]: Feature to highlight and annotate websites is new in latest [[https://elpa.gnu.org/devel/org-remark.html][GNU-devel ELPA]] and is planned to be part of v1.1.0.
+[fn:1]: Feature to highlight and annotate websites is new in the latest [[https://elpa.gnu.org/devel/org-remark.html][GNU-devel ELPA]] and is planned to be part of v1.1.0.
 
 Unless you explicitly load ~org~ during Emacs initialization, we suggest to defer loading ~org-remark~ (thus there is no ~(require 'org-remark)~ in the example above). This is because it will also pull in ~org~, which can slow down initialization. You can control the timing of loading ~org-remark~ by autoloading some commands in a similar way with the example keybindings below.
 

--- a/org-remark-eww.el
+++ b/org-remark-eww.el
@@ -6,7 +6,7 @@
 ;;          Noboru Ota <me@nobiot.com>
 ;; URL: https://github.com/nobiot/org-remark
 ;; Created: 23 December 2022
-;; Last modified: 10 January 2023
+;; Last modified: 11 January 2023
 ;; Package-Requires: ((emacs "27.1") (org "9.4"))
 ;; Keywords: org-mode, annotation, note-taking, marginal-notes, wp
 
@@ -35,7 +35,7 @@
 ;;; Code:
 
 (require 'eww)
-(declare-function org-remark-auto-on "org-remark-global-tracking")
+(require 'org-remark-global-tracking)
 
 ;;;###autoload
 (define-minor-mode org-remark-eww-mode

--- a/org-remark-eww.el
+++ b/org-remark-eww.el
@@ -1,12 +1,12 @@
 ;;; org-remark-eww.el --- Enable Org-remark for EWW -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2021-2022 Free Software Foundation, Inc.
+;; Copyright (C) 2021-2023 Free Software Foundation, Inc.
 
-;; Author: Vedang Manerikar <ved.manerikar@gmail.com>
-;;         Noboru Ota <me@nobiot.com>
+;; Authors: Vedang Manerikar <ved.manerikar@gmail.com>
+;;          Noboru Ota <me@nobiot.com>
 ;; URL: https://github.com/nobiot/org-remark
 ;; Created: 23 December 2022
-;; Last modified: 24 December 2022
+;; Last modified: 10 January 2023
 ;; Package-Requires: ((emacs "27.1") (org "9.4"))
 ;; Keywords: org-mode, annotation, note-taking, marginal-notes, wp
 

--- a/org-remark-global-tracking.el
+++ b/org-remark-global-tracking.el
@@ -5,7 +5,7 @@
 ;; Author: Noboru Ota <me@nobiot.com>
 ;; URL: https://github.com/nobiot/org-remark
 ;; Created: 15 August 2021
-;; Last modified: 10 January 2023
+;; Last modified: 11 January 2023
 ;; Package-Requires: ((emacs "27.1") (org "9.4"))
 ;; Keywords: org-mode, annotation, note-taking, marginal-notes, wp
 
@@ -60,6 +60,16 @@ suffix to the file name without the extension."
 Each one is called with FILENAME as an argument."
   :group 'org-remark
   :type '(repeat function))
+
+(defvar org-remark-source-find-file-name-functions nil
+  "List of functions to get the source file name.
+It is an abnormal hook run with no argument and each function
+must return a file-name-equvalent as a string that uniquely
+identifies the source.  The hook is run when `buffer-file-name`
+in source buffer returns nil, meaning the source buffer is not
+visiting a file.
+
+Meant to be set by extensions such as `org-remark-eww'")
 
 ;;;###autoload
 (define-minor-mode org-remark-global-tracking-mode

--- a/org-remark-global-tracking.el
+++ b/org-remark-global-tracking.el
@@ -1,11 +1,11 @@
 ;;; org-remark-global-tracking.el --- Track files and auto-activate Org-remark -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2021-2022 Free Software Foundation, Inc.
+;; Copyright (C) 2021-2023 Free Software Foundation, Inc.
 
 ;; Author: Noboru Ota <me@nobiot.com>
 ;; URL: https://github.com/nobiot/org-remark
 ;; Created: 15 August 2021
-;; Last modified: 07 January 2023
+;; Last modified: 10 January 2023
 ;; Package-Requires: ((emacs "27.1") (org "9.4"))
 ;; Keywords: org-mode, annotation, note-taking, marginal-notes, wp
 

--- a/org-remark-global-tracking.el
+++ b/org-remark-global-tracking.el
@@ -5,7 +5,7 @@
 ;; Author: Noboru Ota <me@nobiot.com>
 ;; URL: https://github.com/nobiot/org-remark
 ;; Created: 15 August 2021
-;; Last modified: 24 December 2022
+;; Last modified: 07 January 2023
 ;; Package-Requires: ((emacs "27.1") (org "9.4"))
 ;; Keywords: org-mode, annotation, note-taking, marginal-notes, wp
 
@@ -127,10 +127,10 @@ This function is meant to be added to `find-file-hook' by
       (expand-file-name org-remark-notes-file-name user-emacs-directory))))
 
 (defun org-remark-source-find-file-name ()
-  "Assumes that we are currently in the source buffer.
-Returns the filename for the source buffer.  We use this filename
-to identify the source buffer in all operations related to
-marginal notes."
+  "Return the filename for the source buffer.
+We use this filename to identify the source buffer in all
+operations related to marginal notes.
+Assumes that we are currently in the source buffer."
   (let ((filename (or buffer-file-name
                       (run-hook-with-args-until-success
                        'org-remark-source-find-file-name-functions))))

--- a/org-remark.el
+++ b/org-remark.el
@@ -1,6 +1,6 @@
 ;;; org-remark.el --- Highlight & annotate any text files -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2020-2022 Free Software Foundation, Inc.
+;; Copyright (C) 2020-2023 Free Software Foundation, Inc.
 
 ;; Author: Noboru Ota <me@nobiot.com>
 ;; URL: https://github.com/nobiot/org-remark

--- a/org-remark.el
+++ b/org-remark.el
@@ -391,11 +391,11 @@ marginal notes file.  The expected values are nil, :load and
 (when org-remark-create-default-pen-set
   ;; Create default pen set.
   (org-remark-create "red-line"
-                     `(:underline (:color "dark red" :style wave))
-                     `(CATEGORY "review" help-echo "Review this"))
+                     '(:underline (:color "dark red" :style wave))
+                     '(CATEGORY "review" help-echo "Review this"))
   (org-remark-create "yellow"
-                     `(:underline "gold" :background "lemon chiffon")
-                     `(CATEGORY "important")))
+                     '(:inherit default :underline "gold2")
+                     '(CATEGORY "important")))
 
 (defun org-remark-save ()
   "Save all the highlights tracked in current buffer to notes buffer.

--- a/org-remark.el
+++ b/org-remark.el
@@ -1080,12 +1080,15 @@ properties, add prefix \"*\"."
       full-text)))
 
 (defun org-remark-notes-setup (notes-buf source-buf)
-  ;;; Start tracking the source buffer in the notes buffer as local variable.
-  ;;; This adds variable only to the base-buffer and not to the indrect buffer.
-  (with-current-buffer notes-buf
-    (unless (member source-buf org-remark-notes-source-buffers)
-      (cl-pushnew source-buf org-remark-notes-source-buffers)
-      (add-hook 'after-save-hook #'org-remark-notes-sync-with-source nil :local)))
+  "Set up NOTES-BUF and SOURCE-BUF for sync.
+
+Note that this function adds some local variables only to the
+base-buffer of the notes and not to the indirect buffer."
+  (let ((base-buf (or (buffer-base-buffer notes-buf) notes-buf)))
+    (with-current-buffer base-buf
+      (unless (member source-buf org-remark-notes-source-buffers)
+        (cl-pushnew source-buf org-remark-notes-source-buffers)
+        (add-hook 'after-save-hook #'org-remark-notes-sync-with-source nil :local))))
   (with-current-buffer source-buf
     (setq org-remark-source-setup-done t)))
 

--- a/org-remark.el
+++ b/org-remark.el
@@ -417,7 +417,8 @@ in the current buffer.  Each highlight is an overlay."
              (props (overlay-properties h)))
         (org-remark-highlight-save filename beg end props)))
     ;;; Avoid saving the notes buffer if it is the same as the source buffer
-    (unless (eq source-buf notes-buf)
+    (if (eq source-buf notes-buf)
+        (set-buffer-modified-p nil)
       (with-current-buffer notes-buf
         (save-buffer)))))
 

--- a/org-remark.el
+++ b/org-remark.el
@@ -905,9 +905,6 @@ buffer for automatic sync."
            (when (and orgid org-remark-use-org-id)
              (insert (concat "[[id:" orgid "]" "[" title "]]"))))
          (setq notes-props (list :body (org-remark-notes-get-body)))))
-      ;; Save the notes buf to file unless source and notes buffers are
-      ;; the same.
-      (unless (eq notes-buf source-buf) (save-buffer))
       notes-props)))
 
 (defun org-remark-highlight-load (highlight)

--- a/org-remark.el
+++ b/org-remark.el
@@ -6,7 +6,7 @@
 ;; URL: https://github.com/nobiot/org-remark
 ;; Version: 1.0.5
 ;; Created: 22 December 2020
-;; Last modified: 09 January 2023
+;; Last modified: 10 January 2023
 ;; Package-Requires: ((emacs "27.1") (org "9.4"))
 ;; Keywords: org-mode, annotation, note-taking, marginal-notes, wp,
 
@@ -761,7 +761,7 @@ round-trip back to the notes file."
          (when notes-props
            (unless (overlay-get ov 'help-echo)
              (overlay-put ov 'help-echo (plist-get notes-props :body)))
-           (overlay-put ov '_org-remark-note-body
+           (overlay-put ov '*org-remark-note-body
                         (plist-get notes-props :body)))))
       (deactivate-mark)
       (org-remark-highlights-housekeep)

--- a/org-remark.el
+++ b/org-remark.el
@@ -904,6 +904,9 @@ buffer for automatic sync."
            (when (and orgid org-remark-use-org-id)
              (insert (concat "[[id:" orgid "]" "[" title "]]"))))
          (setq notes-props (list :body (org-remark-notes-get-body)))))
+      ;; Save the notes buf to file unless source and notes buffers are
+      ;; the same.
+      (unless (eq notes-buf source-buf) (save-buffer))
       notes-props)))
 
 (defun org-remark-highlight-load (highlight)
@@ -952,7 +955,6 @@ Assume the current buffer is the source buffer."
 ;;    convenience. Users might interact with either the indirect buffer
 ;;    or directly with the base buffer.  For automatic sync
 ;;    functionality, Org-remark interacts directly with the base buffer.
-
 
 (defun org-remark-notes-remove (id &optional delete)
   "Remove the note entry for highlight ID.

--- a/org-remark.el
+++ b/org-remark.el
@@ -845,8 +845,9 @@ ORGID can be passed to this function.  If user option
 Org-ID link in the body text of the headline, linking back to the
 source with using ORGID.
 
-When a new notes file is created, add
-`org-remark-notes-sync-with-source' to `after-save-hook'."
+When the current source buffer is not set up for sync with notes,
+this function calls `org-remark-notes-setup' to prepare the notes
+buffer for automatic sync."
   (let* ((filename (org-remark-source-get-file-name filename))
          (id (plist-get props 'org-remark-id))
          (text (org-with-wide-buffer (buffer-substring-no-properties beg end)))

--- a/org-remark.el
+++ b/org-remark.el
@@ -1099,8 +1099,9 @@ base-buffer of the notes and not to the indirect buffer."
 
 (defun org-remark-notes-update-source (source-buffer)
   "Update SOURCE-BUFFER with marginal notes properties.
-Assume the current buffer is the notes file (indrect or base)."
-  (let* ((notes-buf (current-buffer)))
+This function assumes the current buffer is one visiting the
+notes file (indrect or base)."
+  (let ((notes-buf (current-buffer)))
     (with-current-buffer source-buffer
       (dolist (highlight (org-remark-highlights-get notes-buf))
         (let* ((location (plist-get highlight :location))

--- a/org-remark.el
+++ b/org-remark.el
@@ -762,15 +762,15 @@ round-trip back to the notes file."
            (unless (overlay-get ov 'help-echo)
              (overlay-put ov 'help-echo (plist-get notes-props :body)))
            (overlay-put ov '*org-remark-note-body
-                        (plist-get notes-props :body)))))
+                        (plist-get notes-props :body)))
+         ;; Save the notes buffer when not loading
+         (let ((notes-buf (find-file-noselect (org-remark-notes-get-file-name))))
+           (unless (eq notes-buf (current-buffer))
+             (with-current-buffer notes-buf (save-buffer))))))
       (deactivate-mark)
       (org-remark-highlights-housekeep)
       (org-remark-highlights-sort)
       (setq org-remark-source-setup-done t)
-      ;; Save the notes buffer
-      (let ((notes-buf (find-file-noselect (org-remark-notes-get-file-name))))
-        (unless (eq notes-buf (current-buffer))
-          (with-current-buffer notes-buf (save-buffer))))
       ;; Return overlay
       ov)))
 

--- a/org-remark.el
+++ b/org-remark.el
@@ -6,7 +6,7 @@
 ;; URL: https://github.com/nobiot/org-remark
 ;; Version: 1.0.5
 ;; Created: 22 December 2020
-;; Last modified: 10 January 2023
+;; Last modified: 11 January 2023
 ;; Package-Requires: ((emacs "27.1") (org "9.4"))
 ;; Keywords: org-mode, annotation, note-taking, marginal-notes, wp,
 
@@ -856,7 +856,10 @@ this function calls `org-remark-notes-setup' to prepare the notes
 buffer for automatic sync."
   (let* ((filename (org-remark-source-get-file-name filename))
          (id (plist-get props 'org-remark-id))
-         (text (org-with-wide-buffer (buffer-substring-no-properties beg end)))
+         (text (org-with-wide-buffer
+                (replace-regexp-in-string
+                 "\n" " "
+                 (buffer-substring-no-properties beg end))))
          (notes-buf (find-file-noselect (org-remark-notes-get-file-name)))
          (source-buf (current-buffer))
          (line-num (org-current-line beg))

--- a/org-remark.el
+++ b/org-remark.el
@@ -6,7 +6,7 @@
 ;; URL: https://github.com/nobiot/org-remark
 ;; Version: 1.0.5
 ;; Created: 22 December 2020
-;; Last modified: 08 January 2023
+;; Last modified: 09 January 2023
 ;; Package-Requires: ((emacs "27.1") (org "9.4"))
 ;; Keywords: org-mode, annotation, note-taking, marginal-notes, wp,
 
@@ -872,7 +872,7 @@ buffer for automatic sync."
       (org-remark-notes-setup notes-buf source-buf))
     (with-current-buffer notes-buf
       (when (featurep 'org-remark-convert-legacy) (org-remark-convert-legacy-data))
-      ;;`org-with-wide-buffer is a macro that should work for non-Org file'
+      ;;`org-with-wide-buffer' is a macro that should work for non-Org file
       (org-with-wide-buffer
        (let ((file-headline
               (or (org-find-property
@@ -1319,7 +1319,17 @@ Case 2. The overlay points to no buffer
     ;; annotation when it is.
     (when (and (overlay-buffer ov)
                (= (overlay-start ov) (overlay-end ov)))
-      (when (not buffer-read-only)
+      (when (and (not buffer-read-only)
+                 (not (derived-mode-p 'special-mode)))
+                ;; buffer-size 0 happens for package like nov.el It
+                ;; erases the buffer (size 0) and renders a new page in
+                ;; the same buffer.  In this case, buffer is writable.
+        ;; Removing the notes here is meant to be automatically remove
+        ;; notes when you delete a region that contains a higlight
+        ;; overlay.
+
+        ;; TODO Relying on the current major mode being derived from
+        ;; special-mode is not the best.
         (org-remark-notes-remove (overlay-get ov 'org-remark-id)))
       (delete-overlay ov))
     (unless (overlay-buffer ov)

--- a/org-remark.el
+++ b/org-remark.el
@@ -409,15 +409,15 @@ in the current buffer.  Each highlight is an overlay."
   (org-remark-highlights-housekeep)
   (org-remark-highlights-sort)
   (let ((notes-buf (find-file-noselect (org-remark-notes-get-file-name)))
-        (source-buf (or (buffer-base-buffer) (current-buffer))))
+        (source-buf (or (buffer-base-buffer) (current-buffer)))
+        (filename (org-remark-source-find-file-name)))
+    (dolist (h org-remark-highlights)
+      (let* ((beg (overlay-start h))
+             (end (overlay-end h))
+             (props (overlay-properties h)))
+        (org-remark-highlight-save filename beg end props)))
     ;;; Avoid saving the notes buffer if it is the same as the source buffer
     (unless (eq source-buf notes-buf)
-      (let ((filename (org-remark-source-find-file-name)))
-        (dolist (h org-remark-highlights)
-          (let* ((beg (overlay-start h))
-                 (end (overlay-end h))
-                 (props (overlay-properties h)))
-            (org-remark-highlight-save filename beg end props))))
       (with-current-buffer notes-buf
         (save-buffer)))))
 
@@ -766,6 +766,10 @@ round-trip back to the notes file."
       (org-remark-highlights-housekeep)
       (org-remark-highlights-sort)
       (setq org-remark-source-setup-done t)
+      ;; Save the notes buffer
+      (let ((notes-buf (find-file-noselect (org-remark-notes-get-file-name))))
+        (unless (eq notes-buf (current-buffer))
+          (with-current-buffer notes-buf (save-buffer))))
       ;; Return overlay
       ov)))
 

--- a/org-remark.el
+++ b/org-remark.el
@@ -6,7 +6,7 @@
 ;; URL: https://github.com/nobiot/org-remark
 ;; Version: 1.0.5
 ;; Created: 22 December 2020
-;; Last modified: 26 December 2022
+;; Last modified: 07 January 2023
 ;; Package-Requires: ((emacs "27.1") (org "9.4"))
 ;; Keywords: org-mode, annotation, note-taking, marginal-notes, wp,
 
@@ -27,8 +27,9 @@
 
 ;;; Commentary:
 
-;; This package lets you highlight and annotate any text file with using Org
-;; mode.
+;; This package lets you highlight and annotate any text file with using
+;; Org mode.  For usage, refer to the user manual available as an Info
+;; node by evaluating (info "org remark")
 
 ;;; Code:
 
@@ -130,6 +131,11 @@ returned by `org-remark-notes-get-file-name'.")
 
 ;; TODO org-remark-sync?
 (defvar-local org-remark-notes-setup-done nil)
+(defvar-local org-remark-notes-source-buffers '()
+  "List of source buffers that have loaded current notes buffer.
+Each notes' buffer locally keeps track of the source buffers that
+have loaded notes from itself.  Buffers in this list may be
+killed so that this needs to be checked with `buffer-live-p'.")
 (defvar-local org-remark-source-setup-done nil)
 
 (defvar org-remark-last-notes-buffer nil
@@ -217,7 +223,7 @@ the priority over the excerpt of the marginal notes."
                         #',(intern (format "org-remark-mark-%s" label)))))))))
 
 
-;;;; Commands
+;;;; Minor mode
 
 ;;;###autoload
 (define-minor-mode org-remark-mode
@@ -271,7 +277,7 @@ recommended to turn it on as part of Emacs initialization.
       (remove-hook 'after-save-hook #'org-remark-save t))))
 
 
-;; Org-remark Menu
+;;;; Org-remark Menu
 (defvar org-remark-menu-map
   (make-sparse-keymap "Org-remark"))
 
@@ -343,9 +349,10 @@ recommended to turn it on as part of Emacs initialization.
             (list 'menu-item "Org-remark" org-remark-menu-map))
 
 
-;;;; Other Commands
+;;;; Commands
 
 (add-to-list 'org-remark-available-pens #'org-remark-mark)
+
 ;;;###autoload
 (defun org-remark-mark (beg end &optional id mode)
   "Apply face `org-remark-highlighter' to the region between BEG and END.
@@ -587,7 +594,7 @@ This command is identical with passing a universal argument to
   (org-remark-remove point :delete))
 
 
-;;;; Internal Functions
+;;;; Private Functions
 
 ;;;;; org-remark-find
 ;;    Find a highlight (e.g. next/prev or overlay)
@@ -669,11 +676,16 @@ Optioanlly ID can be passed to find the exacth ID match."
                     found)))
     (car found)))
 
-
-
 
-;;;; org-remark-highlight
-;;   Work on a single highlight
+;;;;; org-remark-highlight
+;;   Functions that work on a single highlight.  A highlight is an
+;;   overlay placed on a a part of text.  With using an analogy of pens
+;;   and books, a highlight is the mark you make over a part of a book
+;;   with a highlighter pen or marker.
+;;
+;;   As highlights are overlays placed on the source buffer, the
+;;   functions here mostly assume the current buffer is the source
+;;   buffer.
 
 (defun org-remark-highlight-mark
     (beg end &optional id mode label face properties)
@@ -696,15 +708,15 @@ MODE determines whether or not highlight is to be saved in the
 marginal notes file.  The expected values are nil, :load and
 :change.
 
-A Org headline entry for the highlight will be created in the
+An Org headline entry for the highlight will be created in the
 marginal notes file specified by `org-remark-notes-get-file-name'.
 If the file does not exist yet, it will be created.
 
 When this function is called from Elisp, ID can be optionally
 passed, indicating to Org-remark that it is to load an existing
 highlight.  In this case, no new ID gets generated and the
-highlight saved again, avoiding the unnecessary round-trip back
-to the database."
+highlight will not be saved again, avoiding the unnecessary
+round-trip back to the notes file."
   ;; Ensure to turn on the local minor mode
   (unless org-remark-mode (org-remark-mode +1))
   ;; When highlights are toggled hidden, only the new one gets highlighted in
@@ -715,7 +727,8 @@ to the database."
         (id (if id id (substring (org-id-uuid) 0 8)))
         (filename (org-remark-source-find-file-name))
         (notes-props))
-    (if (not filename) (message "org-remark: Highlights not saved; buffer is not supported")
+    (if (not filename)
+        (message "org-remark: Highlights not saved; buffer is not supported")
       (org-with-wide-buffer
        (overlay-put ov 'face (if face face 'org-remark-highlighter))
        (while properties
@@ -726,19 +739,18 @@ to the database."
        (overlay-put ov 'org-remark-id id)
        ;; Keep track of the overlay in a local variable. It's a list that is
        ;; guaranteed to contain only org-remark overlays as opposed to the one
-       ;; returned by `overlay-lists' that lists any overlays.
+       ;; returned by `overlay-lists' that lists all overlays.
        (push ov org-remark-highlights)
        ;; for mode, nil and :change result in saving the highlight.  :load
        ;; bypasses save.
        (unless (eq mode :load)
+         ;; Get props for create and change
          (setq notes-props
                (org-remark-highlight-save filename
                                           beg end
                                           (overlay-properties ov)
                                           (org-remark-highlight-get-title)))
-         ;;; Get props for create and change any way
          (when notes-props
-           ;; TODO. The function should be based on parameters
            (unless (overlay-get ov 'help-echo)
              (overlay-put ov 'help-echo (plist-get notes-props :body)))
            (overlay-put ov '_org-remark-note-body
@@ -746,11 +758,20 @@ to the database."
       (deactivate-mark)
       (org-remark-highlights-housekeep)
       (org-remark-highlights-sort)
+      (setq org-remark-source-setup-done t)
       ;; Return overlay
       ov)))
 
 (defun org-remark-highlight-get-title ()
-  "Return the title of the current buffer.
+  "Return the title of the source buffer.
+The title is either the title keyword for an Org buffer, or the
+file name of the source buffer.  When the source is not a
+file (e.g. a website), it is its file name equivalent, such as
+the URL for a website.
+
+This function assumes
+the current buffer is the source buffer.
+
 Utility function to work with a single highlight overlay."
   (or (cadr (assoc "TITLE" (org-collect-keywords '("TITLE"))))
       (let* ((full-name (org-remark-source-find-file-name))
@@ -766,9 +787,11 @@ Utility function to work with a single highlight overlay."
             (file-name-sans-extension (file-name-nondirectory filename))))))
 
 (defun org-remark-highlight-get-org-id (point)
-  "Return Org-ID closest to POINT.
+  "Return Org-ID closest to POINT of the source buffer.
 This function does this only when `org-remark-use-org-id' is
-non-nil.  Returns nil otherwise, or when no Org-ID is found."
+non-nil.  Returns nil otherwise, or when no Org-ID is found.
+
+This function assumes the current buffer is the source buffer."
   (and org-remark-use-org-id
        (org-entry-get point "ID" :inherit)))
 
@@ -777,33 +800,39 @@ non-nil.  Returns nil otherwise, or when no Org-ID is found."
 
 Return the highlight's data properties list (TODO refer to ...).
 
-FILENAME specifies the name of source file with which the marginal notes
-file is associated.
+FILENAME is the name of source file with which the marginal notes
+buffer is associated.  When the source buffer does not visit a
+file (e.g. a website), it is the source buffer's file name
+equivalent, such as the URL.
 
-BEG and END specify the range of the highlight being saved.  It
+BEG and END are the range of the highlight being saved.  It
 is the highlight overlay's start and end.
 
 PROPS are the highlight overlay's properties.  Not all the
 properties will be added as headline properties.  Refer to
 `org-remark-notes-set-properties'.
 
-For the first highlight of the current buffer, this function will
+For the first highlight of the source buffer, this function will
 create a new H1 headline for it at the bottom of the marginal
 notes buffer with TITLE as its headline text.
 
-If it is a new highlight, this function will create a new H2
-headline with the highlighted text as its headline text at the
-end of the H1 headline for the current buffer.
+When called for a new highlight that is unsaved in the marginal
+notes file, this function will create a new H2 headline with the
+highlighted text as its headline text at the end of the H1
+headline for the source buffer.
 
-If headline with the same ID already exists, update its position
-and other \"org-remark-*\" properties (CATEGORY is the exception
-and gets updated as well) from the highlight overlay.  For
-update, the headline text will be kept intact, because the user
-might have changed it to their needs.
+If a headline with the same ID already exists, update its
+position and properties named \"org-remark-*\" and CATEGORY from
+the highlight overlay.  For update, the headline text will be
+kept intact, because the user might have changed it to their
+needs.
 
 This function will also add a normal file link as property
-\"org-remark-link\" of the H2 headline entry back to the current
-buffer with search option \"::line-number\".
+\"org-remark-link\" of the H2 headline entry, pointing back to
+the source file with search option \"::line-number\", or for
+non-file sources, calls `run-hook-with-args-until-success' for
+`org-remark-highlight-link-to-source-functions' with FILENAME as
+the argument.
 
 ORGID can be passed to this function.  If user option
 `org-remark-use-org-id' is non-nil, this function will add an
@@ -816,6 +845,7 @@ When a new notes file is created, add
          (id (plist-get props 'org-remark-id))
          (text (org-with-wide-buffer (buffer-substring-no-properties beg end)))
          (notes-buf (find-file-noselect (org-remark-notes-get-file-name)))
+         (source-buf (current-buffer))
          (main-buf (current-buffer))
          (line-num (org-current-line beg))
          (orgid (org-remark-highlight-get-org-id beg))
@@ -826,7 +856,7 @@ When a new notes file is created, add
                   'org-remark-highlight-link-to-source-functions filename)))
          (notes-props))
     ;;; Set up notes buffer for sync, etc.
-    (org-remark-notes-setup notes-buf (current-buffer) filename)
+    (org-remark-notes-setup notes-buf source-buf)
     (with-current-buffer notes-buf
       (when (featurep 'org-remark-convert-legacy) (org-remark-convert-legacy-data))
       ;;`org-with-wide-buffer is a macro that should work for non-Org file'
@@ -852,7 +882,6 @@ When a new notes file is created, add
                ;; Don't update the headline text when it already exists
                ;; Let the user decide how to manage the headlines
                ;; (org-edit-headline text)
-               ;; FIXME update the line-num in a normal link if any
                (org-remark-notes-set-properties beg end props))
            ;; No headline with the marginal notes ID property. Create a new one
            ;; at the end of the file's entry
@@ -867,7 +896,7 @@ When a new notes file is created, add
            (org-remark-notes-set-properties beg end props)
            (when (and orgid org-remark-use-org-id)
              (insert (concat "[[id:" orgid "]" "[" title "]]"))))
-         (setq notes-props (list :body (org-remark-notes-get-text)))))
+         (setq notes-props (list :body (org-remark-notes-get-body)))))
       ;; (cond
       ;;  ;; fix GH issue #19
       ;;  ;; Temporarily remove `org-remark-save' from the `after-save-hook'
@@ -895,15 +924,37 @@ When a new notes file is created, add
         )
       notes-props)))
 
+(defun org-remark-highlight-load (highlight)
+  "Load a single HIGHLIGHT to the source buffer.
+Assume the current buffer is the source buffer."
+  (let* ((id (plist-get highlight :id))
+         (location (plist-get highlight :location))
+         (beg (car location))
+         (end (cdr location))
+         (label (plist-get highlight :label))
+         (ov nil)
+         (props (plist-get highlight :props)))
+    (let ((fn (intern (concat "org-remark-mark-" label))))
+      (unless (functionp fn) (setq fn #'org-remark-mark))
+      (setq ov (funcall fn beg end id :load))
+      ;; TODO Generalize the part that updates properties.
+      ;; :body should not be the fixed property.
+      ;; '(:text (val . fn) :prop1 (val . fn) :prop2 (val .fn))
+      ;; (dolist list)
+      (unless (overlay-get ov 'help-echo)
+        (overlay-put ov 'help-echo (plist-get props :body)))
+      (overlay-put ov '*org-remark-note-body
+                   (plist-get props :body)))))
+
 
 ;;;;; org-remark-notes
 ;;    Work on marginal notes
 
 (defun org-remark-notes-remove (id &optional delete)
-  "Remove the highlight entry for ID for current buffer.
+  "Remove the note entry for highlight ID for current buffer.
 By default, it deletes only the properties of the entry keeping
-the headline intact.  You can pass DELETE and delete the all
-notes of the entry.
+the headline intact.  You can pass DELETE and delete the body of
+the note entry.
 
 Return t if an entry is removed or deleted."
   (let* ((ibuf (org-remark-notes-buffer-get-or-create))
@@ -995,7 +1046,7 @@ drawer."
         (org-set-property p v))))
   t)
 
-(defun org-remark-notes-get-text ()
+(defun org-remark-notes-get-body ()
   "Return the text body of a highlight in the notes buffer."
   (let ((full-text
          (save-excursion
@@ -1013,90 +1064,40 @@ drawer."
         (substring-no-properties full-text 0 200)
       full-text)))
 
-
-
-;;;;; org-remark-highlights
-;;    Work on all the highlights in the current buffer
-
-(defvar-local org-remark-notes-source-buffers '()
-  "List of source buffers that have loaded the notes.
-Each note's buffer locally keeps track of the source buffers that
-have loaded notes from itself.  Buffers in this list may be
-killed so that this needs to be checked with `buffer-live-p'.")
-
-(defun org-remark-highlight-load (highlight)
-  (let* ((id (plist-get highlight :id))
-         (location (plist-get highlight :location))
-         (beg (car location))
-         (end (cdr location))
-         (label (plist-get highlight :label))
-         (ov nil)
-         (props (plist-get highlight :props)))
-    (let ((fn (intern (concat "org-remark-mark-" label))))
-      (unless (functionp fn) (setq fn #'org-remark-mark))
-      (setq ov (funcall fn beg end id :load))
-      ;; TODO Generalize the part that updates properties.
-      ;; :body should not be the fixed property.
-      ;; '(:text (val . fn) :prop1 (val . fn) :prop2 (val .fn))
-      ;; (dolist list)
-      (unless (overlay-get ov 'help-echo)
-        (overlay-put ov 'help-echo (plist-get props :body)))
-      (overlay-put ov '*org-remark-note-body
-                   (plist-get props :body)))))
-
-(defun org-remark-highlights-load ()
-  "Visit `org-remark-notes-file' & load the saved highlights onto current buffer.
-If there is no highlights or annotations for current buffer,
-output a message in the echo.
-
-Highlights tracked locally by variable `org-remark-highlights'
-cannot persist when you kill current buffer or quit Emacs.  It is
-recommended to set `org-remark-global-tracking-mode' in your
-configuration.  It automatically turns on `org-remark-mode'.
-
-Otherwise, do not forget to turn on `org-remark-mode' manually to
-load the highlights"
-  ;; Loop highlights and add them to the current buffer
-  (let ((notes-buf (find-file-noselect (org-remark-notes-get-file-name)))
-        (source-file-name (org-remark-source-get-file-name
-                           (org-remark-source-find-file-name)))
-        (source-buf (current-buffer)))
-    (dolist (highlight (org-remark-highlights-get notes-buf source-file-name))
-      (org-remark-highlight-load highlight))
-    (org-remark-notes-setup notes-buf source-buf source-file-name)
-    (setq org-remark-source-setup-done t))
-  t)
-
-(defun org-remark-notes-setup (notes-buf source-buf source-file-name)
+(defun org-remark-notes-setup (notes-buf source-buf)
   ;;; Start tracking the source buffer in the notes buffer as local variable.
   ;;; This adds variable only to the base-buffer and not to the indrect buffer.
   (let ((source-setup-done org-remark-source-setup-done))
     (with-current-buffer notes-buf
       (unless (and org-remark-notes-setup-done source-setup-done)
-        (cl-pushnew (cons source-buf source-file-name)
-                    org-remark-notes-source-buffers)
+        (cl-pushnew source-buf org-remark-notes-source-buffers)
         (add-hook 'after-save-hook #'org-remark-notes-sync-with-source nil :local)
         (setq org-remark-notes-setup-done t)))))
 
 (defun org-remark-notes-housekeep ()
  "Remove killed buffers from `org-remark-notes-source-buffers'."
  (setq org-remark-notes-source-buffers
-       (seq-filter #'(lambda (pair) (buffer-live-p (car pair)))
-                   org-remark-notes-source-buffers)))
+       (seq-filter #'buffer-live-p org-remark-notes-source-buffers)))
 
-(defun org-remark-notes-update-source (source-buffer source-file-name)
-  "Update source with notes props.
-Trigger by on-save of the notes."
-  ;; Assume the current buffer is the notes file (indrect or base).
-  (let* ((new-highlights
-          (org-remark-highlights-get (current-buffer) source-file-name)))
+(defun org-remark-notes-update-source (source-buffer)
+  "Update SOURCE-BUFFER with marginal notes properties.
+It is meant to be set to `after-save-buffer' of the notes buffer.
+
+SOURCE-FILE-NAME is the
+
+Assume the current buffer is the notes file (indrect or base)."
+  (let* ((notes-buf (current-buffer)))
     (with-current-buffer source-buffer
-      (dolist (highlight new-highlights)
+      (dolist (highlight (org-remark-highlights-get notes-buf))
         (let* ((location (plist-get highlight :location))
                (beg (car location))
                (end (cdr location))
                (id (plist-get highlight :id))
                (ov (org-remark-find-overlay-in beg end id)))
+          ;; In order to update the overlay, it is first gets deleted
+          ;; and newly loaded.  This way, we avoid duplicate of the same
+          ;; highlight.
+
           ;; FIXME Currently the when clause is used to guard against
           ;; the case where a highlight overlay is not found.  It should
           ;; be an edge case but the highlight could have moved to a
@@ -1110,27 +1111,27 @@ Trigger by on-save of the notes."
 It is meant to be used in `after-save-hook'.
 Look at the base buffer for org-remark-notes-source-buffers."
   ;;; Assume the current buffer is either the indirect or notes buffer
-  ;;; in question.
+  ;;; in question.  In order for the `after-save-hook' to correctly
+  ;;; triggers notes sync, we need to get the base buffer if the note
+  ;;; buffer is an indirect one.
   (let* ((notes-buffer (or (buffer-base-buffer) (current-buffer))))
     (with-current-buffer notes-buffer
       (org-remark-notes-housekeep)
-      (dolist (pair org-remark-notes-source-buffers)
-        ;; pair is (SOURCE-BUF . SOURCE-FILE-NAME)
-        ;; SOUCE-FILE-NAME is the reference used in notes file
-        (let ((source-buf (car pair))
-              (source-file-name (cdr pair)))
-          (org-remark-notes-update-source source-buf source-file-name))))))
+      (dolist (source-buf org-remark-notes-source-buffers)
+        (org-remark-notes-update-source source-buf)))))
 
-(defun org-remark-highlights-get (notes-buf source-file-name)
-  "Return a list of highlights from the marginal notes file.
+(defun org-remark-highlights-get (notes-buf)
+  "Return a list of highlights from the marginal NOTES-BUF.
 The file name is returned by `org-remark-notes-get-file-name'.
-Each highlight is a property list in the following properties:
+It is assumed that the current buffer is source buffer.  Each
+highlight is a property list in the following properties:
     (:id ID :location (BEG . END) :label LABEL :props '(PROPERTIES)"
   ;; Set source-file-name first, as `find-file-noselect' will set the
   ;; current-buffer to source-file-name. Issue #39 FIXME: A way to make
   ;; this sequence agnostic is preferred, if there is a function that
   ;; visit file but not set the current buffer
-  (when-let ((source-file-name source-file-name)
+  (when-let ((source-file-name (org-remark-source-get-file-name
+                                (org-remark-source-find-file-name)))
              (notes-buf notes-buf))
     ;; TODO check if there is any relevant notes for the current file
     ;; This can be used for adding icon to the highlight
@@ -1160,13 +1161,37 @@ Each highlight is a property list in the following properties:
                           (end (string-to-number
                                 (org-entry-get (point)
                                                org-remark-prop-source-end)))
-                          (text (org-remark-notes-get-text)))
+                          (text (org-remark-notes-get-body)))
                  (push (list :id id
                              :location (cons beg end)
                              :label    (org-entry-get (point) "org-remark-label")
                              :props    (list :body text))
                        highlights))))
            highlights))))))
+
+
+;;;;; org-remark-highlights
+;;    Work on all the highlights in the current buffer
+
+(defun org-remark-highlights-load ()
+  "Visit `org-remark-notes-file' & load the saved highlights onto current buffer.
+If there is no highlights or annotations for current buffer,
+output a message in the echo.
+
+Highlights tracked locally by variable `org-remark-highlights'
+cannot persist when you kill current buffer or quit Emacs.  It is
+recommended to set `org-remark-global-tracking-mode' in your
+configuration.  It automatically turns on `org-remark-mode'.
+
+Otherwise, do not forget to turn on `org-remark-mode' manually to
+load the highlights"
+  ;; Loop highlights and add them to the current buffer
+  (let ((notes-buf (find-file-noselect (org-remark-notes-get-file-name)))
+        (source-buf (current-buffer)))
+    (dolist (highlight (org-remark-highlights-get notes-buf))
+      (org-remark-highlight-load highlight))
+    (org-remark-notes-setup notes-buf source-buf))
+  t)
 
 (defun org-remark-highlights-get-positions (&optional reverse)
   "Return list of the beginning point of all visible highlights in this buffer.

--- a/org-remark.el
+++ b/org-remark.el
@@ -1336,7 +1336,12 @@ function extends the behavior and looks for the word at point"
     ;; Check beg end is required as the cursor may be on an empty point with no
     ;; word under it.
     (if (and beg end)
-        (list beg end)
+        (progn
+          (when (> beg end)
+            (let ((large beg))
+              (setq beg end
+                    end large)))
+          (list beg end))
       (user-error "No region selected and the cursor is not on a word"))))
 
 


### PR DESCRIPTION
"notes-sync" feature was merged to main toward the end of year 2022. This was premature and has introduced a volume of new problems and regressions, especially around the existing save function -- for an obvious interaction between "notes-sync" and "save-highlights". The new notes-sync feature updates information from notes buffer to its related sources (1 to N). The existing save-highlights functionality goes the other direction from a source buffer to its related notes buffer.

I have been conducting more careful and thorough regressions, and along the way fixing issues new and regression. Also clarifying the doc strings, which was also missing.

Sincere apologies for those who have been affected (even though you might not have voiced your dismay and frustrations).  

I believe I have fixed many and most annoying issues, and collectively this PR should bring the main branch (when merged) to work in the same way for existing features in the eyes of end users, with only the benefit of notes-sync. 

I will leave this PR unmerged with main for now -- probably for a couple of days to se if there is any glaring issues. If this appears stable, I will merge it to the main. 


