### PR TITLE
fix demoted error from implementation of `org-remark-report-no-highlights`

### DIFF
--- a/org-remark.el
+++ b/org-remark.el
@@ -1618,9 +1618,10 @@ highlight is a property list in the following properties:
         (org-with-wide-buffer
          (let ((heading (org-find-property
                          org-remark-prop-source-file source-file-name)))
-           (if (and (not heading) org-remark-report-no-highlights)
-               (message "No highlights or annotations found for %s."
-                        source-file-name)
+           (if (not heading)
+               (when org-remark-report-no-highlights
+                 (message "No highlights or annotations found for %s."
+                          source-file-name))
              (goto-char heading)
              ;; Narrow to only subtree for a single file.  `org-find-property'
              ;; ensures that it is the beginning of a headline


### PR DESCRIPTION
This fixes a bug introduced by 574f90d6299b6688f57830d590ca41d39ed4bceb. (Apologies, that was my PR and I hadn't noticed this bug initially because `org-remark-highlights-load` uses `with-demoted-errors`.)

Currently, if `org-remark-report-no-highlights` is non-nil and there are no highlights in the current file, then `org-remark-highlights-get` will incorrectly execute code relevant to showing highlights (throwing an error which is demoted to a message) due to erroneous logic. This commit fixes the erroneous logic.