### PR TITLE
fix: org-remark-info-mode interfering with isearch-forward #93

### DIFF
--- a/org-remark-info.el
+++ b/org-remark-info.el
@@ -5,7 +5,7 @@
 ;; Author: Noboru Ota <me@nobiot.com>
 ;; URL: https://github.com/nobiot/org-remark
 ;; Created: 16 July 2023
-;; Last modified: 22 January 2025
+;; Last modified: 23 January 2025
 ;; Package-Requires: ((emacs "27.1") (org "9.4"))
 ;; Keywords: org-mode, annotation, note-taking, marginal-notes, wp
 
@@ -74,13 +74,13 @@
                     #'org-remark-info-get-node)
           (add-hook 'org-remark-highlight-link-to-source-functions
                     #'org-remark-info-link)
-          (advice-add #'Info-find-node :after #'org-remark-info-highlights-load))
+          (add-hook 'Info-selection-hook #'org-remark-info-highlights-load))
     ;; Disable
     (remove-hook 'org-remark-source-find-file-name-functions
                  #'org-remark-info-get-node)
     (remove-hook 'org-remark-highlight-link-to-source-functions
                  #'org-remark-info-link)
-    (advice-remove #'Info-find-node #'org-remark-info-highlights-load)))
+    (remove-hook 'Info-selection-hook #'org-remark-info-highlights-load)))
 
 (defun org-remark-info-highlights-load (&rest _args)
   "Wrapper for `org-remark-highlights-load'.

--- a/org-remark-info.el
+++ b/org-remark-info.el
@@ -5,7 +5,7 @@
 ;; Author: Noboru Ota <me@nobiot.com>
 ;; URL: https://github.com/nobiot/org-remark
 ;; Created: 16 July 2023
-;; Last modified: 21 January 2024
+;; Last modified: 22 January 2025
 ;; Package-Requires: ((emacs "27.1") (org "9.4"))
 ;; Keywords: org-mode, annotation, note-taking, marginal-notes, wp
 
@@ -74,15 +74,13 @@
                     #'org-remark-info-get-node)
           (add-hook 'org-remark-highlight-link-to-source-functions
                     #'org-remark-info-link)
-          (advice-add #'Info-find-node :after #'org-remark-info-highlights-load)
-          (advice-add #'Info-search :after #'org-remark-info-highlights-load))
+          (advice-add #'Info-find-node :after #'org-remark-info-highlights-load))
     ;; Disable
     (remove-hook 'org-remark-source-find-file-name-functions
                  #'org-remark-info-get-node)
     (remove-hook 'org-remark-highlight-link-to-source-functions
                  #'org-remark-info-link)
-    (advice-remove #'Info-find-node #'org-remark-info-highlights-load)
-    (advice-remove #'Info-search #'org-remark-info-highlights-load)))
+    (advice-remove #'Info-find-node #'org-remark-info-highlights-load)))
 
 (defun org-remark-info-highlights-load (&rest _args)
   "Wrapper for `org-remark-highlights-load'.


### PR DESCRIPTION
With my light testing, I didn't find any regression, but I do not recall why I thought the `org-remark-info-highlights-load` was needed after `Info-search`. Please report if you encounter any regression.


This is a quick band-aid patch for lack of my capacity (= time) at the moment. It needs more thorough investigation and testing -- help would be appreciated. 