### PR TITLE
feat: Support Org's CUSTOM_ID in addition to Org-ID #96

### DIFF
--- a/org-remark.el
+++ b/org-remark.el
@@ -1060,7 +1060,9 @@ non-nil.  Returns nil otherwise, or when no Org-ID is found.
 This function assumes the current buffer is the source buffer."
   (and org-remark-use-org-id
        (derived-mode-p 'org-mode)
-       (org-entry-get point "ID" :inherit)))
+       (if (eq org-remark-use-org-id 'custom_id)
+           (org-entry-get point "CUSTOM_ID" :inherit)
+         (org-entry-get point "ID" :inherit))))
 
 (define-obsolete-function-alias
   'org-remark-highlight-save 'org-remark-highlight-add "1.2.0"
@@ -1264,8 +1266,11 @@ beginning of source-headline, which should be one level up."
           ;; headline is created. No update afterwards
           (plist-put props "org-remark-original-text" text)
           (org-remark-notes-set-properties props)
-          (when (and orgid org-remark-use-org-id)
-            (insert (concat "[[id:" orgid "]" "[" title "]]"))))
+          (when orgid
+            (if (eq org-remark-use-org-id 'custom_id)
+                (insert
+                 (concat "[[file:" filename "::#" orgid "]" "[" title "]]"))
+              (insert (concat "[[id:" orgid "]" "[" title "]]")))))
         (list :body (org-remark-notes-get-body)
               :original-text text)))))
 


### PR DESCRIPTION
To use this new feature, do `(setq org-remark-use-org-id 'custom_id)`.

TODO The defcustom is not adjusted yet (it's still boolean).